### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:v0.26.0->v0.26.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.26.0"
+  tag: "v0.26.1"
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher


### PR DESCRIPTION
*Release Notes*:
``` noteworthy operator github.com/gardener/machine-controller-manager #405 @prashanth26
Prepend mcm to all work queue metrics
```

``` noteworthy operator github.com/gardener/machine-controller-manager #405 @prashanth26
Subsystems and Namespaces to MCM metrics
```

``` noteworthy operator github.com/gardener/machine-controller-manager #405 @prashanth26
Renamed mcm_machine_deployment_items_total & mcm_machine_set_items_total metrics
```