### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:v0.26.1->v0.26.3]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.26.1"
+  tag: "v0.26.3"
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/machine-controller-manager #409 @prashanth26
Set deleteOnTermination flag to true while deleting the VMs in AWS.
```

``` noteworthy operator github.com/gardener/machine-controller-manager #408 @hardikdr
Bugfix: Set deleteOnTermination to true by default for volumes. Disks that are created with the instance are deleted with instance termination.
```