### PR TITLE
[ci:component:github.com/gardener/terraformer:0.19.0->0.20.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.19.0"
+  tag: "0.20.0"
 - name: cloud-controller-manager
   sourceRepository: https://github.com/packethost/packet-ccm
   repository: docker.io/packethost/packet-ccm


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/terraformer #35 @dkistner
Update Terraform `azurerm` provider to support Azure NatGateway.
```