### PR TITLE
Support for Kubernetes 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.1.5
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/gardener/etcd-druid v0.1.3
-	github.com/gardener/gardener v1.1.1-0.20200323102039-58593d8be86a
+	github.com/gardener/gardener v1.1.1-0.20200323153040-38affa645e44
 	github.com/gardener/gardener-extensions v1.5.0
 	github.com/gardener/machine-controller-manager v0.26.0
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/gardener/external-dns-management v0.7.3 h1:SAW9ur2mjZ+x89xbmcplJgqNUm
 github.com/gardener/external-dns-management v0.7.3/go.mod h1:Y3om11E865x4aQ7cmcHjknb8RMgCO153huRb/SvP+9o=
 github.com/gardener/gardener v1.1.1-0.20200311075931-7f7e52b986e7 h1:UD25lsw3fYBK7pUlXkGwUXmlpnksG9JbdwC75XZTBOQ=
 github.com/gardener/gardener v1.1.1-0.20200311075931-7f7e52b986e7/go.mod h1:lGAx5NkFDWoC4hPIL+lHJamafBxmOt5MrHq9hGtp5VI=
-github.com/gardener/gardener v1.1.1-0.20200323102039-58593d8be86a h1:TkMIvx1xRmd3xLuORXEqsQhpni49+wfuT4keC6d3Tsc=
-github.com/gardener/gardener v1.1.1-0.20200323102039-58593d8be86a/go.mod h1:lGAx5NkFDWoC4hPIL+lHJamafBxmOt5MrHq9hGtp5VI=
+github.com/gardener/gardener v1.1.1-0.20200323153040-38affa645e44 h1:65uT6h9kAtc9P+JvinkGRSu8nuMN2b0LYqWvNpg5C0k=
+github.com/gardener/gardener v1.1.1-0.20200323153040-38affa645e44/go.mod h1:lGAx5NkFDWoC4hPIL+lHJamafBxmOt5MrHq9hGtp5VI=
 github.com/gardener/gardener-extensions v1.5.0 h1:6JkU0/DV2bJvwkuPoP7/nPlyCrzPGKfw5j4f+wtXBeI=
 github.com/gardener/gardener-extensions v1.5.0/go.mod h1:yCdFgMAz++ex3d1fmhN3Yti9MR9HN9iKTUjz5eI0uIQ=
 github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=

--- a/vendor/github.com/gardener/gardener/pkg/client/kubernetes/client.go
+++ b/vendor/github.com/gardener/gardener/pkg/client/kubernetes/client.go
@@ -228,6 +228,7 @@ var supportedKubernetesVersions = []string{
 	"1.15",
 	"1.16",
 	"1.17",
+	"1.18",
 }
 
 func checkIfSupportedKubernetesVersion(gitVersion string) error {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -52,7 +52,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
 github.com/gardener/external-dns-management/pkg/client/dns/clientset/versioned/scheme
-# github.com/gardener/gardener v1.1.1-0.20200323102039-58593d8be86a
+# github.com/gardener/gardener v1.1.1-0.20200323153040-38affa645e44
 github.com/gardener/gardener/pkg/api/extensions
 github.com/gardener/gardener/pkg/apis/core
 github.com/gardener/gardener/pkg/apis/core/install


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for 1.18 to the extension.

**Which issue(s) this PR fixes**:
* Part of gardener/gardener#2095

**Special notes for your reviewer**:
I have not validated it but as Packet is using an external CCM and CSI already it should be pretty similar to https://github.com/gardener/gardener-extension-provider-alicloud/pull/58.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The Packet extension does now support shoot clusters with Kubernetes version 1.18. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.18.md) before upgrading to 1.18.
```