### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:v0.27.0->v0.28.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.27.0"
+  tag: "v0.28.0"
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/machine-controller-manager #451 @zuzzas
The mcm stopped adopting Nodes with empty ProviderID field
```

``` improvement operator github.com/gardener/machine-controller-manager #447 @prashanth26
Bugfix: Continue with VM deletion when data disk doesn't exist for AWS.
```

``` improvement user github.com/gardener/machine-controller-manager #442 @zuzzas
Provide a way to specify "auth-extra-groups" field in created bootstrap tokens.
```

``` improvement user github.com/gardener/machine-controller-manager #441 @zuzzas
Support multiple network interfaces in the AWS driver
```

``` improvement operator github.com/gardener/machine-controller-manager #414 @tennix
Add GCP local ssd disk support
```

``` improvement developer github.com/gardener/machine-controller-manager #397 @guydaichs
Added support for multiple Data Disks in Azure and AliCloud.
```