### PR TITLE
[ci:component:github.com/gardener/terraformer:v1.0.0->v1.1.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "v1.0.0"
+  tag: "v1.1.0"
 - name: cloud-controller-manager
   sourceRepository: https://github.com/packethost/packet-ccm
   repository: docker.io/packethost/packet-ccm


### PR DESCRIPTION
*Release Notes*:
``` noteworthy operator github.com/gardener/terraformer #39 @minchaow
Terraform version has been upgraded to `0.12.20`.
```

``` improvement operator github.com/gardener/terraformer #39 @minchaow
Provider `alicloud` version has been upgraded to `1.84.0`.
```