### PR TITLE
[trigger new PR] [ci:component:github.com/gardener/machine-controller-manager:v0.31.0->v0.32.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.31.0"
+  tag: "v0.32.0"
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher


### PR DESCRIPTION
*Release Notes*:
``` improvement developer github.com/gardener/machine-controller-manager #480 @prashanth26
Bugfix: Drain machines with only a valid node (name)
```

``` improvement operator github.com/gardener/machine-controller-manager #457 @zuzzas
Added an option to use configDrive in the OpenStackMachineClass
```