### PR TITLE
Populate worker-configuration in machine deployment

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -134,16 +134,17 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		)
 
 		machineDeployments = append(machineDeployments, worker.MachineDeployment{
-			Name:           deploymentName,
-			ClassName:      className,
-			SecretName:     className,
-			Minimum:        pool.Minimum,
-			Maximum:        pool.Maximum,
-			MaxSurge:       pool.MaxSurge,
-			MaxUnavailable: pool.MaxUnavailable,
-			Labels:         pool.Labels,
-			Annotations:    pool.Annotations,
-			Taints:         pool.Taints,
+			Name:                 deploymentName,
+			ClassName:            className,
+			SecretName:           className,
+			Minimum:              pool.Minimum,
+			Maximum:              pool.Maximum,
+			MaxSurge:             pool.MaxSurge,
+			MaxUnavailable:       pool.MaxUnavailable,
+			Labels:               pool.Labels,
+			Annotations:          pool.Annotations,
+			Taints:               pool.Taints,
+			MachineConfiguration: genericworkeractuator.ReadMachineConfiguration(pool),
 		})
 
 		machineClassSpec["name"] = className


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:  This PR populates the controller-configurations on the machine-deployment from worker-object.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-packet/issues/63

**Special notes for your reviewer**:
The following dependencies need to be resolved.
- [x] Vendor the MCM 0.33.0
- [x] https://github.com/gardener/gardener/pull/2563 should be merged.
- [x]  g/g with the #2563 change should be vendored. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Worker extension allows configuring following parameters on machine-deployment: drainTimeout, creationTimeout, healthTimeout, maxEvictRetries, nodeConditions.
```
