### PR TITLE
Use region as facility instead of zones

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -122,7 +122,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			"projectID":    string(machineClassSecretData[packet.ProjectID]),
 			"billingCycle": "hourly",
 			"machineType":  pool.MachineType,
-			"facility":     pool.Zones,
+			"facility":     []string{w.worker.Spec.Region},
 			"sshKeys":      []string{infrastructureStatus.SSHKeyID},
 			"tags": []string{
 				fmt.Sprintf("kubernetes.io/cluster/%s", w.worker.Namespace),

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -118,9 +118,6 @@ var _ = Describe("Machines", func() {
 				maxSurgePool2       intstr.IntOrString
 				maxUnavailablePool2 intstr.IntOrString
 
-				zone1 = region + "a"
-				zone2 = region + "b"
-
 				machineConfiguration *machinev1alpha1.MachineConfiguration
 
 				workerPoolHash1 string
@@ -139,7 +136,7 @@ var _ = Describe("Machines", func() {
 				namespace = "shoot--foobar--packet"
 				cloudProfileName = "packet"
 
-				region = "eu-west-1"
+				region = "ewr1"
 				packetAPIToken = "api-token"
 				packetProjectID = "project-id"
 
@@ -162,9 +159,6 @@ var _ = Describe("Machines", func() {
 				maxPool2 = 45
 				maxSurgePool2 = intstr.FromInt(10)
 				maxUnavailablePool2 = intstr.FromInt(15)
-
-				zone1 = region + "a"
-				zone2 = region + "b"
 
 				machineConfiguration = &machinev1alpha1.MachineConfiguration{}
 
@@ -242,8 +236,7 @@ var _ = Describe("Machines", func() {
 								},
 								UserData: userData,
 								Zones: []string{
-									zone1,
-									zone2,
+									region,
 								},
 							},
 							{
@@ -259,8 +252,7 @@ var _ = Describe("Machines", func() {
 								},
 								UserData: userData,
 								Zones: []string{
-									zone1,
-									zone2,
+									region,
 								},
 							},
 						},
@@ -292,8 +284,7 @@ var _ = Describe("Machines", func() {
 						"billingCycle": "hourly",
 						"machineType":  machineType,
 						"facility": []string{
-							zone1,
-							zone2,
+							region,
 						},
 						"sshKeys": []string{sshKeyID},
 						"tags": []string{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority normal

**What this PR does / why we need it**:

Equinix Metal doesn't have the notion of availability zones as other cloud providers do. While likely possible technically, spanning a k8s cluster across multiple geographical regions is usually discouraged in the k8s community. Therefore, use the specified **region** as the only value passed in the "facility" field of all worker pools.

Without this change, deploying a shoot using the following cloud profile and shoot manifests fails:

```yaml
---
apiVersion: core.gardener.cloud/v1beta1
kind: CloudProfile
metadata:
  name: packet-flatcar
spec:
  type: packet
  kubernetes:
    versions:
    - version: 1.19.3
    - version: 1.18.12
  machineImages:
  - name: flatcar
    versions:
    - version: 0.0.0-stable
  machineTypes:
  - name: t1.small
    cpu: "4"
    gpu: "0"
    memory: 8Gi
    usable: true
  volumeTypes:
  - name: storage_1
    class: standard
    usable: true
  - name: storage_2
    class: performance
    usable: true
  regions:
  - name: ams1
  providerConfig:
    apiVersion: packet.provider.extensions.gardener.cloud/v1alpha1
    kind: CloudProfileConfig
    machineImages:
    - name: flatcar
      versions:
      - version: 0.0.0-stable
        id: flatcar_stable
```

```yaml
---
apiVersion: core.gardener.cloud/v1alpha1
kind: Shoot
metadata:
  name: my-em-cluster
  namespace: garden
spec:
  seedName: aws
  cloudProfileName: packet-flatcar
  region: ams1
  secretBindingName: core-packet
  provider:
    type: packet
    infrastructureConfig:
      apiVersion: packet.provider.extensions.gardener.cloud/v1alpha1
      kind: InfrastructureConfig
    controlPlaneConfig:
      apiVersion: packet.provider.extensions.gardener.cloud/v1alpha1
      kind: ControlPlaneConfig
    workers:
    - name: worker-xoluy
      machine:
        type: t1.small
      minimum: 2
      maximum: 2
  networking:
    nodes: 10.80.128.0/25
    type: calico
  kubernetes:
    version: 1.18.12
  maintenance:
    autoUpdate:
      kubernetesVersion: true
      machineImageVersion: true
  addons:
    kubernetes-dashboard:
      enabled: true
    nginx-ingress:
      enabled: true
```

```
    Description:  task "Waiting until shoot worker nodes have been reconciled" failed: Error while waiting for Worker shoot--garden--my-em-cluster/my-em-cluster to become ready: extension encountered error during reconciliation: Error reconciling worker: failed to deploy the machine classes: failed to apply manifests: 1 error occurred: could not read object: error 'error converting YAML to JSON: yaml: line 24: could not find expected ':'' decoding manifest:
---
# Source: machineclass/templates/machineclass.yaml

---
apiVersion: v1
kind: Secret
metadata:
  name: shoot--garden--my-em-cluster-worker-xoluy-89d7d
  namespace: shoot--garden--my-em-cluster
  labels:
    gardener.cloud/purpose: machineclass

type: Opaque
data:
  userData: REDACTED
  apiToken: REDACTED
---
apiVersion: machine.sapcloud.io/v1alpha1
kind: PacketMachineClass
metadata:
  name: shoot--garden--my-em-cluster-worker-xoluy-89d7d
  namespace: shoot--garden--my-em-cluster
spec:
  projectID: REDACTED
  OS: flatcar_stable
  billingCycle: hourly
  machineType: t1.small
  sshKeys:
    - REDACTED

  secretRef:
    name: shoot--garden--my-em-cluster-worker-xoluy-89d7d
    namespace: shoot--garden--my-em-cluster
  tags:
    - kubernetes.io/cluster/shoot--garden--my-em-cluster
    - kubernetes.io/role/node

  facility:
  null
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Packet facility is now handled correctly.
```
