### PR TITLE
Set facility name in CCM chart

### DIFF
--- a/charts/internal/seed-controlplane/charts/packet-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/packet-cloud-controller-manager/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
             secretKeyRef:
               name: cloudprovider
               key: projectID
+        {{- if .Values.facility }}
+        - name: PACKET_FACILITY_NAME
+          value: {{ .Values.facility }}
+        {{- end }}
         ports:
         # Packet's CCM is based on K8S 1.11 and uses 10253 port by default.
         - containerPort: 10253

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -238,6 +238,7 @@ func getControlPlaneChartValues(
 				"checksum/secret-cloud-controller-manager": checksums[packet.CloudControllerManagerImageName],
 				"checksum/secret-cloudprovider":            checksums[v1beta1constants.SecretNameCloudProvider],
 			},
+			"facility": cluster.Shoot.Spec.Region,
 		},
 		"csi-packet": map[string]interface{}{
 			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -84,6 +84,7 @@ var _ = Describe("ValuesProvider", func() {
 							Enabled: true,
 						},
 					},
+					Region: "ewr1",
 				},
 			},
 		}
@@ -126,6 +127,7 @@ var _ = Describe("ValuesProvider", func() {
 					"checksum/secret-cloud-controller-manager": "3d791b164a808638da9a8df03924be2a41e34cd664e42231c00fe369e3588272",
 					"checksum/secret-cloudprovider":            "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
 				},
+				"facility": "ewr1",
 			},
 			"csi-packet": map[string]interface{}{
 				"replicas":          1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/priority normal

**What this PR does / why we need it**:

The Packet CCM allows specifying the Packet facility in two ways: Using an env var and using the Packet metadata service.

When deploying a Packet shoot with a seed which runs outside of Packet, the CCM which runs in the seed is crashlooping because it can't communicate with the Packet metadata service to figure out the facility automatically.

Since the Spec.Region key of the Shoot resource seems to be required, looks like we can always specify the facility explicitly. Doing so allows using non-Packet seeds and shouldn't have any effect for Packet seeds as far as I can tell.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Packet facility is now explicitly passed to the CCM. This allows running the CCM in seed clusters which don't run on Packet.
```
