### PR TITLE
Add platform/equinix-metal label to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -21,6 +21,7 @@ If multiple identifiers make sense you can also state the commands multiple time
 /area TODO
 /kind bug
 /priority normal
+/platform equinix-metal
 
 **What happened**:
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -21,6 +21,7 @@ If multiple identifiers make sense you can also state the commands multiple time
 /area TODO
 /kind enhancement
 /priority normal
+/platform equinix-metal
 
 **What would you like to be added**:
 

--- a/.github/ISSUE_TEMPLATE/flaking-test.md
+++ b/.github/ISSUE_TEMPLATE/flaking-test.md
@@ -24,6 +24,7 @@ If multiple identifiers make sense you can also state the commands multiple time
 /area testing
 /kind flake
 /priority normal
+/platform equinix-metal
 
 **Which test(s)/suite(s) are flaking**:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@ For Gardener Enhancement Proposals (GEPs), please check the following [documenta
 /area TODO
 /kind TODO
 /priority normal
+/platform equinix-metal
 
 **What this PR does / why we need it**:
 

--- a/hack/update-github-templates.sh
+++ b/hack/update-github-templates.sh
@@ -25,6 +25,7 @@ for file in `find "$(dirname $0)"/../vendor/github.com/gardener/gardener/.github
     sed 's/operating Gardener/working with this Gardener extension/g' |\
     sed 's/to the Gardener project/for this extension/g' |\
     sed 's/to Gardener/to this extension/g' |\
-    sed 's/- Gardener version:/- Gardener version (if relevant):\n- Extension version:/g' \
+    sed 's/- Gardener version:/- Gardener version (if relevant):\n- Extension version:/g' |\
+    sed 's/\/priority normal/\/priority normal\n\/platform equinix-metal/g' \
   > "$(dirname $0)/../.github/${file#*.github/}"
 done


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Add `platform/equinix-metal` label to templates.
Should be available by tomorrow.
