### PR TITLE
docs: updates and improvements

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -96,7 +96,7 @@ spec:
     nodes: 10.250.0.0/16
     type: calico
   kubernetes:
-    version: 1.16.1
+    version: 1.20.2
   maintenance:
     autoUpdate:
       kubernetesVersion: true

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -93,7 +93,10 @@ spec:
         size: 50Gi
         type: storage_1
   networking:
-    nodes: 10.250.0.0/16
+    # This field must be set to Management CIDR allocated by Packet when you create first machine
+    # in a selected region.
+    # See also https://github.com/gardener/gardener-extension-provider-packet/issues/107.
+    nodes: 10.250.0.0/25
     type: calico
   kubernetes:
     version: 1.20.2

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -73,7 +73,7 @@ metadata:
   namespace: garden-dev
 spec:
   cloudProfileName: packet
-  region: EWR1
+  region: ewr1
   secretBindingName: core-packet
   provider:
     type: packet

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -23,6 +23,19 @@ data:
 
 Please look up https://www.packet.com/developers/api/ as well.
 
+With `Secret` created, create a `SecretBinding` resource referencing it. It may look like this:
+
+```yaml
+apiVersion: core.gardener.cloud/v1beta1
+kind: SecretBinding
+metadata:
+  name: core-packet
+  namespace: garden-dev
+secretRef:
+  name: core-packet
+quotas: []
+```
+
 ## `InfrastructureConfig`
 
 Currently, there is no infrastructure configuration possible for the Packet environment.

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -39,7 +39,7 @@ spec:
     class: performance
     usable: true
   regions:
-  - name: EWR1
+  - name: ewr1
   providerConfig:
     apiVersion: packet.provider.extensions.gardener.cloud/v1alpha1
     kind: CloudProfileConfig

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -19,7 +19,7 @@ spec:
     versions:
     - version: 1.16.1
     - version: 1.16.0
-      expirationDate: "2020-04-05T01:02:03Z"
+      #expirationDate: "2020-04-05T01:02:03Z"
   machineImages:
   - name: coreos
     versions:

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -17,8 +17,9 @@ spec:
   type: packet
   kubernetes:
     versions:
-    - version: 1.16.1
-    - version: 1.16.0
+    - version: 1.20.2
+    - version: 1.19.7
+    - version: 1.18.15
       #expirationDate: "2020-04-05T01:02:03Z"
   machineImages:
   - name: coreos

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -4,23 +4,6 @@ The [`core.gardener.cloud/v1alpha1.CloudProfile` resource](https://github.com/ga
 
 In this document we are describing how this configuration looks like for Packet and provide an example `CloudProfile` manifest with minimal configuration that you can use to allow creating Packet shoot clusters.
 
-## `CloudProfileConfig`
-
-The cloud profile configuration contains information about the real machine image IDs in the Packet environment (IDs).
-You have to map every version that you specify in `.spec.machineImages[].versions` here such that the Packet extension knows the ID for every version you want to offer.
-
-An example `CloudProfileConfig` for the Packet extension looks as follows:
-
-```yaml
-apiVersion: packet.provider.extensions.gardener.cloud/v1alpha1
-kind: CloudProfileConfig
-machineImages:
-- name: coreos
-  versions:
-  - version: 2135.6.0
-    id: coreos-2135.6.0-id
-```
-
 ## Example `CloudProfile` manifest
 
 Please find below an example `CloudProfile` manifest:
@@ -65,3 +48,22 @@ spec:
       - version: 2135.6.0
         id: coreos-2135.6.0-id
 ```
+
+## `CloudProfileConfig`
+
+The cloud profile configuration contains information about the real machine image IDs in the Packet environment (IDs).
+You have to map every version that you specify in `.spec.machineImages[].versions` here such that the Packet extension knows the ID for every version you want to offer.
+
+An example `CloudProfileConfig` for the Packet extension looks as follows:
+
+```yaml
+apiVersion: packet.provider.extensions.gardener.cloud/v1alpha1
+kind: CloudProfileConfig
+machineImages:
+- name: coreos
+  versions:
+  - version: 2135.6.0
+    id: coreos-2135.6.0-id
+```
+
+> NOTE: `CloudProfileConfig` is not a Custom Resource, so you cannot create it directly.

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -22,9 +22,9 @@ spec:
     - version: 1.18.15
       #expirationDate: "2020-04-05T01:02:03Z"
   machineImages:
-  - name: coreos
+  - name: flatcar
     versions:
-    - version: 2135.6.0
+    - version: 0.0.0-stable
   machineTypes:
   - name: t1.small
     cpu: "4"
@@ -44,10 +44,10 @@ spec:
     apiVersion: packet.provider.extensions.gardener.cloud/v1alpha1
     kind: CloudProfileConfig
     machineImages:
-    - name: coreos
+    - name: flatcar
       versions:
-      - version: 2135.6.0
-        id: coreos-2135.6.0-id
+      - version: 0.0.0-stable
+        id: flatcar_stable
 ```
 
 ## `CloudProfileConfig`
@@ -61,10 +61,10 @@ An example `CloudProfileConfig` for the Packet extension looks as follows:
 apiVersion: packet.provider.extensions.gardener.cloud/v1alpha1
 kind: CloudProfileConfig
 machineImages:
-- name: coreos
+- name: flatcar
   versions:
-  - version: 2135.6.0
-    id: coreos-2135.6.0-id
+  - version: 0.0.0-stable
+    id: flatcar_stable
 ```
 
 > NOTE: `CloudProfileConfig` is not a Custom Resource, so you cannot create it directly.

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -55,7 +55,7 @@ var _ = Describe("ValuesProvider", func() {
 				Namespace: namespace,
 			},
 			Spec: extensionsv1alpha1.ControlPlaneSpec{
-				Region: "EWR1",
+				Region: "ewr1",
 				SecretRef: corev1.SecretReference{
 					Name:      v1beta1constants.SecretNameCloudProvider,
 					Namespace: namespace,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/priority normal
/platform equinix-metal

**What this PR does / why we need it**:
This PR updates and clarifies some of existing documentation.

**Which issue(s) this PR fixes**:
Initial cleanup to prepare for #109. 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
