### PR TITLE
migrate to use out-of-tree MCM EM provider

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,6 +11,10 @@ images:
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
   tag: "v0.38.0"
+- name: machine-controller-manager-provider-equinix-metal
+  sourceRepository: github.com/gardener/machine-controller-manager-provider-equinix-metal
+  repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-equinix-metal
+  tag: "v0.1.0"
 - name: metabot
   sourceRepository: github.com/packethost/metabot
   repository: packethost/metabot

--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -36,24 +36,51 @@ spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
       containers:
-      - name: packet-machine-controller-manager
+      - name: machine-controller-manager-provider-equinix-metal
+        image: {{ index .Values.images "machine-controller-manager-provider-equinix-metal" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - ./machine-controller
+        - --control-kubeconfig=inClusterConfig
+        - --machine-creation-timeout=20m
+        - --machine-drain-timeout=2h
+        - --machine-health-timeout=10m
+        - --namespace={{ .Release.Namespace }}
+        - --port={{ .Values.metricsPortEquinixMetal }}
+        - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
+        - --v=3
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: {{ .Values.metricsPortEquinixMetal }}
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/machine-controller-manager
+          name: machine-controller-manager
+          readOnly: true
+      - name: machine-controller-manager
         image: {{ index .Values.images "machine-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
         - ./machine-controller-manager
         - --control-kubeconfig=inClusterConfig
-        - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
-        - --namespace={{ .Release.Namespace }}
-        - --port={{ .Values.metricsPort }}
-        - --machine-creation-timeout=20m
-        - --machine-drain-timeout=2h
-        - --machine-health-timeout=10m
+        - --delete-migrated-machine-class=true
         - --machine-safety-apiserver-statuscheck-timeout=30s
         - --machine-safety-apiserver-statuscheck-period=1m
         - --machine-safety-orphan-vms-period=30m
         - --machine-safety-overshooting-period=1m
+        - --namespace={{ .Release.Namespace }}
+        - --port={{ .Values.metricsPort }}
         - --safety-up=2
         - --safety-down=1
+        - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
         - --v=3
         livenessProbe:
           failureThreshold: 3

--- a/charts/internal/machine-controller-manager/seed/values.yaml
+++ b/charts/internal/machine-controller-manager/seed/values.yaml
@@ -1,5 +1,6 @@
 images:
   machine-controller-manager: image-repository:image-tag
+  machine-controller-manager-equinix-metal: image-repository:image-tag
 
 replicas: 1
 
@@ -11,6 +12,7 @@ namespace:
   uid: uuid-of-namespace
 
 metricsPort: 10258
+metricsPortEquinixMetal: 10259
 
 vpa:
   enabled: true

--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -15,11 +15,11 @@ data:
   apiToken: {{ $machineClass.secret.apiToken | b64enc }}
 ---
 apiVersion: machine.sapcloud.io/v1alpha1
-kind: PacketMachineClass
+kind: MachineClass
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
-spec:
+providerSpec:
   projectID: {{ $machineClass.projectID }}
   OS: {{ $machineClass.OS }}
   billingCycle: {{ $machineClass.billingCycle }}
@@ -30,13 +30,17 @@ spec:
   metadata:
 {{ toYaml $machineClass.metadata | indent 2 }}
 {{- end }}
-  secretRef:
-    name: {{ $machineClass.name }}
-    namespace: {{ $.Release.Namespace }}
 {{- if $machineClass.tags }}
   tags:
 {{ toYaml $machineClass.tags | indent 4 }}
 {{- end }}
   facility:
 {{ toYaml $machineClass.facility | indent 2 }}
+secretRef:
+  name: {{ $machineClass.name }}
+  namespace: {{ $.Release.Namespace }}
+credentialsSecretRef:
+  name: {{ $machineClass.credentialsSecretRef.name }}
+  namespace: {{ $machineClass.credentialsSecretRef.namespace }}
+provider: "EquinixMetal"
 {{- end }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -11,9 +11,12 @@ machineClasses:
   machineType: t1.small
   sshKeys:
   - 12345-abcd567-aaf2
-  secret:
-    cloudConfig: abc
-    apiToken: "abd5678"
   tags:
   - kubernetes.io/cluster/foo
   - kubernetes.io/role/node
+  secret:
+    cloudConfig: abc
+    apiToken: "abd5678"
+  credentialsSecretRef:
+    name: cloudprovider
+    namespace: shoot-namespace

--- a/pkg/controller/worker/machine_controller_manager.go
+++ b/pkg/controller/worker/machine_controller_manager.go
@@ -33,7 +33,7 @@ var (
 	mcmChart = &chart.Chart{
 		Name:   packet.MachineControllerManagerName,
 		Path:   filepath.Join(packet.InternalChartsPath, packet.MachineControllerManagerName, "seed"),
-		Images: []string{packet.MachineControllerManagerImageName},
+		Images: []string{packet.MachineControllerManagerImageName, packet.MachineControllerManagerEquinixMetalImageName},
 		Objects: []*chart.Object{
 			{Type: &appsv1.Deployment{}, Name: packet.MachineControllerManagerName},
 			{Type: &corev1.Service{}, Name: packet.MachineControllerManagerName},

--- a/pkg/packet/types.go
+++ b/pkg/packet/types.go
@@ -26,6 +26,8 @@ const (
 	CloudControllerManagerImageName = "cloud-controller-manager"
 	// MachineControllerManagerImageName is the name of the MachineControllerManager image.
 	MachineControllerManagerImageName = "machine-controller-manager"
+	// MachineControllerManagerEquinixMetalImageName is the name of the MachineControllerManager EquinixMetal providerimage.
+	MachineControllerManagerEquinixMetalImageName = "machine-controller-manager-equinix-metal"
 
 	// BucketName is a constant for the key in a backup secret that holds the bucket name.
 	// The bucket name is written to the backup secret by Gardener as a temporary solution.


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

Migrates to the new [out-of-tree Equinix Metal MCM provider](https://github.com/gardener/machine-controller-manager-provider-equinix-metal)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
use out-of-tree MCM provider
```
