### PR TITLE
Fix bug in `controlplane` webhook when new `Deployment`s are created

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -81,6 +81,10 @@ func (e *ensurer) EnsureVPNSeedServerDeployment(_ context.Context, _ gcontext.Ga
 }
 
 func keepNodeNetworkEnvVarIfPresentInOldDeployment(new, old *appsv1.Deployment, containerName string) {
+	if old == nil {
+		return
+	}
+
 	// Preserve NODE_NETWORK env variable in vpn-seed container. The Worker controller sets this flag at the end of its
 	// reconciliation, however, the kube-apiserver deployment is created earlier, so let's keep the value until the
 	// Worker controller updates it. This is to not trigger avoidable rollouts/restarts.

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err = ensurer.EnsureKubeAPIServerDeployment(ctx, dummyContext, dep, dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(ctx, dummyContext, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			checkKubeAPIServerDeployment(dep, annotations)
 		})
@@ -145,7 +145,7 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err = ensurer.EnsureKubeAPIServerDeployment(ctx, dummyContext, dep, dep)
+			err = ensurer.EnsureKubeAPIServerDeployment(ctx, dummyContext, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			checkKubeAPIServerDeployment(dep, annotations)
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
When new `Deployment`s are created then `old` is `nil`, however, this was not properly handled.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
