### PR TITLE
Allow NODE_NETWORK env var to change its value

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -106,6 +106,12 @@ func keepNodeNetworkEnvVarIfPresentInOldDeployment(new, old *appsv1.Deployment, 
 	}
 
 	if newContainer != nil && nodeNetworkEnvVarValue != "" {
+		for _, env := range newContainer.Env {
+			if env.Name == nodeNetworkEnvVarName && env.Value != nodeNetworkEnvVarValue {
+				return
+			}
+		}
+
 		newContainer.Env = extensionswebhook.EnsureEnvVarWithName(newContainer.Env, corev1.EnvVar{
 			Name:  nodeNetworkEnvVarName,
 			Value: nodeNetworkEnvVarValue,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Earlier, if `NODE_NETWORK` was present in the old container, it was always kept (with the same value) even if the value was trying to be changed in the new deployment. However, the actual desired behaviour is to keep `NODE_NETWORK` only if it is trying to be removed.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
