### PR TITLE
Support for Metros and (multiple) Facilities

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -34,8 +34,11 @@ providerSpec:
   tags:
 {{ toYaml $machineClass.tags | indent 4 }}
 {{- end }}
-  facility:
-{{ toYaml $machineClass.facility | indent 2 }}
+  metro: {{ $machineClass.metro }}
+{{- if $machineClass.facilities }}
+  facilities:
+{{ toYaml $machineClass.facilities | indent 2 }}
+{{- end }}
 {{- if $machineClass.reservationIDs }}
   reservationIDs:
 {{ $machineClass.reservationIDs | toYaml | indent 2 }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -5,7 +5,8 @@ machineClasses:
   projectID: abcd-1234-fff
   OS: alpine_3
   billingCycle: hourly
-  facility:
+  metro: ny
+  facilities:
   - ewr1
   description: An optional description for machines created by that class.
   machineType: t1.small

--- a/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/deployment.yaml
@@ -52,9 +52,9 @@ spec:
             secretKeyRef:
               name: cloudprovider
               key: projectID
-        {{- if .Values.facility }}
+        {{- if .Values.metro }}
         - name: METAL_FACILITY_NAME
-          value: {{ .Values.facility }}
+          value: {{ .Values.metro }}
         {{- end }}
         # Required to make CCM manage MetalLB ConfigMap.
         - name: METAL_LB

--- a/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/values.yaml
@@ -11,3 +11,4 @@ resources:
   limits:
     cpu: 500m
     memory: 512Mi
+metro: ny

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -98,7 +98,7 @@ metadata:
   namespace: garden-dev
 spec:
   cloudProfileName: packet
-  region: ewr1
+  region: ny # Corresponds to a metro
   secretBindingName: core-packet
   provider:
     type: packet
@@ -117,6 +117,9 @@ spec:
       volume:
         size: 50Gi
         type: storage_1
+      zones: # Optional list of facilities, all of which MUST be in the metro; if not provided, then random facilities within the metro will be chosen for each machine.
+      - ewr1
+      - ny5
     - name: reserved-pool
       machine:
         type: t1.small
@@ -150,3 +153,6 @@ spec:
     nginx-ingress:
       enabled: true
 ```
+
+⚠️ Note that if you specify multiple facilities in the `.spec.provider.workers[].zones[]` list then new machines are randomly created in one of the provided facilities.
+Particularly, it is not ensured that all facilities are used or that all machines are equally or unequally distributed.

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -31,15 +31,12 @@ spec:
     gpu: "0"
     memory: 8Gi
     usable: true
-  volumeTypes:
-  - name: storage_1
-    class: standard
-    usable: true
-  - name: storage_2
-    class: performance
-    usable: true
-  regions:
-  - name: ewr1
+  regions: # List of offered metros
+  - name: ny
+    zones: # List of offered facilities within the respective metro
+    - name: ewr1
+    - name: ny5
+    - name: ny7
   providerConfig:
     apiVersion: packet.provider.extensions.gardener.cloud/v1alpha1
     kind: CloudProfileConfig

--- a/example/26-cloudprofile.yaml
+++ b/example/26-cloudprofile.yaml
@@ -29,8 +29,12 @@ spec:
   #- name: storage_2
   #  class: performance
   #  usable: true
-  regions:
-  - name: ewr1
+  regions: # List of offered metros
+  - name: ny
+    zones: # List of offered facilities within the respective metro
+    - name: ewr1
+    - name: ny5
+    - name: ny7
   providerConfig:
     apiVersion: packet.provider.extensions.gardener.cloud/v1alpha1
     kind: CloudProfileConfig

--- a/example/30-controlplane.yaml
+++ b/example/30-controlplane.yaml
@@ -50,7 +50,7 @@ metadata:
   namespace: shoot--foobar--packet
 spec:
   type: packet
-  region: WER1
+  region: ny
   secretRef:
     name: cloudprovider
     namespace: shoot--foobar--packet

--- a/example/30-infrastructure.yaml
+++ b/example/30-infrastructure.yaml
@@ -40,7 +40,7 @@ metadata:
   namespace: shoot--foobar--packet
 spec:
   type: packet
-  region: ewr1
+  region: ny
   secretRef:
     name: cloudprovider
     namespace: shoot--foobar--packet

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -51,7 +51,7 @@ metadata:
     gardener.cloud/operation: reconcile
 spec:
   type: packet
-  region: ewr1
+  region: ny
   secretRef:
     name: cloudprovider
     namespace: shoot--foobar--packet
@@ -84,3 +84,4 @@ spec:
     userData: IyEvYmluL2Jhc2gKCmVjaG8gImhlbGxvIHdvcmxkIgo=
     zones:
     - ewr1
+    - ny5

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretBindingName: provider-secret
   cloudProfileName: packet
-  region: ewr1  # this must be one of the regions in the above-referenced profile
+  region: ny  # this must be one of the regions in the above-referenced profile
   purpose: evaluation # {testing,development,production,infrastructure}, "infrastructure" purpose only usable for shoots in garden namespace
   provider:
     type: packet   # this tells it which provider type to use
@@ -25,6 +25,9 @@ spec:
         image:
           name: ubuntu
           version: "20.04"
+      zones:
+      - ewr1
+      - ny5
   kubernetes:
     version: 1.19.7
     kubelet:

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -181,7 +181,7 @@ func getControlPlaneChartValues(
 				"checksum/secret-cloud-controller-manager": checksums[packet.CloudControllerManagerImageName],
 				"checksum/secret-cloudprovider":            checksums[v1beta1constants.SecretNameCloudProvider],
 			},
-			"facility": cluster.Shoot.Spec.Region,
+			"metro": cluster.Shoot.Spec.Region,
 		},
 		"metallb": map[string]interface{}{},
 	}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -65,7 +65,7 @@ var _ = Describe("ValuesProvider", func() {
 							Enabled: true,
 						},
 					},
-					Region: "ewr1",
+					Region: "ny",
 				},
 			},
 		}
@@ -106,7 +106,7 @@ var _ = Describe("ValuesProvider", func() {
 					"checksum/secret-cloud-controller-manager": "3d791b164a808638da9a8df03924be2a41e34cd664e42231c00fe369e3588272",
 					"checksum/secret-cloudprovider":            "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
 				},
-				"facility": "ewr1",
+				"metro": "ny",
 			},
 			"metallb": map[string]interface{}{},
 		}
@@ -128,7 +128,7 @@ var _ = Describe("ValuesProvider", func() {
 				Namespace: namespace,
 			},
 			Spec: extensionsv1alpha1.ControlPlaneSpec{
-				Region: "EWR1",
+				Region: "ny",
 				SecretRef: corev1.SecretReference{
 					Name:      v1beta1constants.SecretNameCloudProvider,
 					Namespace: namespace,

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -136,7 +136,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			"projectID":    string(machineClassSecretData[packet.ProjectID]),
 			"billingCycle": "hourly",
 			"machineType":  pool.MachineType,
-			"facility":     []string{w.worker.Spec.Region},
+			"metro":        w.worker.Spec.Region,
 			"sshKeys":      []string{infrastructureStatus.SSHKeyID},
 			"tags": []string{
 				fmt.Sprintf("kubernetes.io/cluster/%s", w.worker.Namespace),
@@ -149,6 +149,10 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"name":      w.worker.Spec.SecretRef.Name,
 				"namespace": w.worker.Spec.SecretRef.Namespace,
 			},
+		}
+
+		if len(pool.Zones) > 0 {
+			machineClassSpec["facilities"] = pool.Zones
 		}
 
 		if len(workerConfig.ReservationIDs) > 0 {

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -97,6 +97,8 @@ var _ = Describe("Machines", func() {
 				packetAPIToken  string
 				packetProjectID string
 				region          string
+				facility1       string
+				facility2       string
 
 				machineImageName    string
 				machineImageVersion string
@@ -136,7 +138,9 @@ var _ = Describe("Machines", func() {
 				namespace = "shoot--foobar--packet"
 				cloudProfileName = "packet"
 
-				region = "ewr1"
+				region = "ny"
+				facility1 = "ewr1"
+				facility2 = "ny5"
 				packetAPIToken = "api-token"
 				packetProjectID = "project-id"
 
@@ -236,7 +240,8 @@ var _ = Describe("Machines", func() {
 								},
 								UserData: userData,
 								Zones: []string{
-									region,
+									facility1,
+									facility2,
 								},
 							},
 							{
@@ -251,9 +256,6 @@ var _ = Describe("Machines", func() {
 									Version: machineImageVersion,
 								},
 								UserData: userData,
-								Zones: []string{
-									region,
-								},
 							},
 						},
 					},
@@ -283,10 +285,8 @@ var _ = Describe("Machines", func() {
 						"projectID":    packetProjectID,
 						"billingCycle": "hourly",
 						"machineType":  machineType,
-						"facility": []string{
-							region,
-						},
-						"sshKeys": []string{sshKeyID},
+						"metro":        region,
+						"sshKeys":      []string{sshKeyID},
 						"tags": []string{
 							fmt.Sprintf("kubernetes.io/cluster/%s", namespace),
 							"kubernetes.io/role/node",
@@ -309,6 +309,8 @@ var _ = Describe("Machines", func() {
 
 					addNameAndSecretToMachineClass(machineClassPool1, packetAPIToken, machineClassWithHashPool1, w.Spec.SecretRef)
 					addNameAndSecretToMachineClass(machineClassPool2, packetAPIToken, machineClassWithHashPool2, w.Spec.SecretRef)
+
+					machineClassPool1["facilities"] = []string{facility1, facility2}
 
 					machineClasses = map[string]interface{}{"machineClasses": []map[string]interface{}{
 						machineClassPool1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR adds support for metros and multiple facilities. Earlier, a facility name was provided in the `.spec.region` field of a `Shoot`. In the future, `.spec.region` must contain the name of a metro. Facilities can be optionally provided in `.spec.provider.workers[].zones[]`.

**Special notes for your reviewer**:
✅ Depends on https://github.com/gardener/machine-controller-manager-provider-equinix-metal/pull/7 and a new release (see #164)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Metros and (multiple) facilities are now supported.
```
