### PR TITLE
Properly configure metrics-server for EQXM devices

### DIFF
--- a/pkg/webhook/shoot/metrics_server.go
+++ b/pkg/webhook/shoot/metrics_server.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"context"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func (m *mutator) mutateMetricsServerDeployment(_ context.Context, deployment *appsv1.Deployment) error {
+	if c := extensionswebhook.ContainerWithName(deployment.Spec.Template.Spec.Containers, "metrics-server"); c != nil {
+		c.Command = extensionswebhook.EnsureStringWithPrefix(c.Command, "--kubelet-preferred-address-types=", "InternalIP,ExternalIP")
+	}
+
+	return nil
+}

--- a/pkg/webhook/shoot/metrics_server_test.go
+++ b/pkg/webhook/shoot/metrics_server_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"context"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Mutator", func() {
+	Describe("#mutateMetricsServerDeployment", func() {
+		It("should correctly set the preferred address types", func() {
+			var (
+				mutator    = &mutator{}
+				deployment = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "metrics-server",
+						Namespace: metav1.NamespaceSystem,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "metrics-server",
+										Command: []string{
+											"/metrics-server",
+											"--authorization-always-allow-paths=/livez,/readyz",
+											"--profiling=false",
+											"--cert-dir=/home/certdir",
+											"--secure-port=8443",
+											"--kubelet-insecure-tls",
+											"--kubelet-preferred-address-types=Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP",
+											"--tls-cert-file=/srv/metrics-server/tls/tls.crt",
+											"--tls-private-key-file=/srv/metrics-server/tls/tls.key",
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			)
+
+			Expect(mutator.mutateMetricsServerDeployment(context.TODO(), deployment)).To(Succeed())
+
+			c := extensionswebhook.ContainerWithName(deployment.Spec.Template.Spec.Containers, "metrics-server")
+			Expect(c).To(Not(BeNil()))
+			Expect(c.Command).To(ContainElement("--kubelet-preferred-address-types=InternalIP,ExternalIP"))
+		})
+	})
+})

--- a/pkg/webhook/shoot/mutator.go
+++ b/pkg/webhook/shoot/mutator.go
@@ -50,6 +50,9 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 	switch x := new.(type) {
 	case *appsv1.Deployment:
 		switch x.Name {
+		case "metrics-server":
+			extensionswebhook.LogMutation(logger, x.Kind, x.Namespace, x.Name)
+			return m.mutateMetricsServerDeployment(ctx, x)
 		case "vpn-shoot":
 			extensionswebhook.LogMutation(logger, x.Kind, x.Namespace, x.Name)
 			return m.mutateVPNShootDeployment(ctx, x)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Typically, the `metrics-server` tries to use the `Hostname` of `Node`s in order to communicate with the kubelet and query metrics. However, pods running on EQXM devices cannot resolve the hostname of the device, hence, the `metrics-server` fails and never becomes ready:

```
E0825 15:16:48.838291       1 scraper.go:139] "Failed to scrape node" err="Get \"https://shoot--foo--bar-pool1-88875-p9p5r:10250/stats/summary?only_cpu_and_memory=true\": dial tcp: lookup shoot--foo--bar-pool1-88875-p9p5r on <ip-address>:53: no such host" node="shoot--foo--bar-pool1-88875-p9p5r"
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `metrics-server` is now properly able to communicate with the kubelets in order to expose metrics about nodes and pods.
```
