### PR TITLE
wrong variable METAL_LB and url format

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/deployment.yaml
@@ -57,8 +57,8 @@ spec:
           value: {{ .Values.metro }}
         {{- end }}
         # Required to make CCM manage MetalLB ConfigMap.
-        - name: METAL_LB
-          value: metallb://
+        - name: METAL_LOAD_BALANCER
+          value: metallb:///
         ports:
         # Equinix Metal's CCM is based on K8S 1.11 and uses 10253 port by default.
         - containerPort: 10253


### PR DESCRIPTION

**How to categorize this PR?**
Semantic typo in the yaml.

according to https://github.com/equinix/cloud-provider-equinix-metal#metallb ,
we need to set `METAL_LOAD_BALANCER` to `metallb:///`; Notice the *three slashes
