### PR TITLE
specify METAL_FACILITY_NAME correctly

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/values.yaml
@@ -11,4 +11,4 @@ resources:
   limits:
     cpu: 500m
     memory: 512Mi
-metro: ny
+metro: ewr1


### PR DESCRIPTION
`METAL_FACILITY_NAME=ny` does not exist.
The zone, `ewr1`, is more appropriate, and works for clusters/machines spawned in that region/zone.

**Special notes for your reviewer**:
This exposes a systematic question with the metallb.
1) if METAL_FACILITY_NAME is not specified, the CCM "reads it from metadata on host on which CCM is running, else error".
2) but with Gardener, the control plane (and thus the CCM), is not running co-located with the workers. In fact your control plane might be running on AWS or OVH. But even within eqxm, the seed could be running in a different region.
3) Hence, METAL_FACILITY_NAME must be specified imperatively. 

@deitch this information probably needs to be derived from the cloudprofile selected for the shoot:
```
...
  regions:
  - name: ny
    zones:
    - name: ewr1
    - name: ny5
    - name: ny7
 ```
Don't know enough about the equinix internals, but what if I have a multizonal cluster? In the example above, is it sufficient to select just `ewr1`? Is the LoadBalancer IP from `ewr1` still functional, if that zone goes down (i.e. is it just used as IPAM)?
