### PR TITLE
update to latest CCM from Equinix Metal, explicit metro support

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/equinix/cloud-provider-equinix-metal
   repository: docker.io/equinix/cloud-provider-equinix-metal
-  tag: v3.2.0
+  tag: v3.3.0
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               name: cloudprovider
               key: projectID
         {{- if .Values.metro }}
-        - name: METAL_FACILITY_NAME
+        - name: METAL_METRO_NAME
           value: {{ .Values.metro }}
         {{- end }}
         # Required to make CCM manage MetalLB ConfigMap.


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:

Bumps Equinix Metal CCM to 3.3.0. Includes several fixes, notable for this extension provider, explicitly handles metro and facility separately. It mixed them before, which caused errors when allocating an Elastic IP for load balancers.

This uses the latest with the fixes, and also uses the new explicit env var API to set it

**Special notes for your reviewer**:

This should get a new release as soon as it is in, my recommendation is a patch release. cc @rfranzke as I cannot do releases.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Latest CCM with fixes
```
