### PR TITLE
Remove the "garden.sapcloud.io/role" label from control plane components

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: machine-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
     app: kubernetes
     role: machine-controller-manager
 spec:
@@ -23,7 +22,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
-        garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         app: kubernetes
         role: machine-controller-manager
         networking.gardener.cloud/to-dns: allowed

--- a/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: cloud-controller-manager
-    garden.sapcloud.io/role: controlplane
 spec:
   revisionHistoryLimit: 0
   replicas: {{ .Values.replicas }}
@@ -17,7 +16,7 @@ spec:
     metadata:
       labels:
         app: cloud-controller-manager
-        garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed

--- a/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/service.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: cloud-controller-manager
-    garden.sapcloud.io/role: controlplane
 spec:
   type: ClusterIP
   clusterIP: None


### PR DESCRIPTION
/kind cleanup

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/422

Ref gardener/gardener#1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
