### PR TITLE
Add check for the docforge manifest

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -14,4 +14,4 @@ mkdir -p /go/src/github.com/gardener/gardener-extension-provider-equinix-metal
 cp -r . /go/src/github.com/gardener/gardener-extension-provider-equinix-metal
 cd /go/src/github.com/gardener/gardener-extension-provider-equinix-metal
 
-make verify-extended
+make verify-extended check-docforge

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /local
 **/dev
 /bin
+hack/tools/bin
 
 *.coverprofile
 *.html

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,13 @@ ifeq ($(WEBHOOK_CONFIG_MODE), service)
 endif
 
 #########################################
+# Tools                                 #
+#########################################
+
+TOOLS_DIR := hack/tools
+include vendor/github.com/gardener/gardener/hack/tools.mk
+
+#########################################
 # Rules for local development scenarios #
 #########################################
 
@@ -118,6 +125,10 @@ check-generate:
 check:
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./pkg/... ./test/...
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check-charts.sh ./charts
+
+.PHONY: check-docforge
+check-docforge: $(DOCFORGE)
+	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check-docforge.sh $(REPO_ROOT) $(REPO_ROOT)/.docforge/manifest.yaml ".docforge/;docs/" "gardener-extension-provider-equinix-metal" false
 
 .PHONY: generate
 generate:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/platform equinix-metal

**What this PR does / why we need it**:
Add new `check-docforge` PR check which will validate the docforge manifest and the documentation linked from it

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
New `check-docforge` step will be executed on each PR
```
