### PR TITLE
Support for Kubernetes v1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.23 | untested    | N/A                      |
 | Kubernetes 1.22 | untested    | N/A                      |
 | Kubernetes 1.21 | untested    | N/A                      |
 | Kubernetes 1.20 | untested    | N/A                      |
@@ -31,11 +32,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.17 | untested    | N/A                      |
 | Kubernetes 1.16 | 1.16.0+     | N/A                      |
 | Kubernetes 1.15 | 1.15.0+     | N/A                      |
-| Kubernetes 1.14 | 1.14.0+     | N/A                      |
-| Kubernetes 1.13 | 1.13.0+     | N/A                      |
-| Kubernetes 1.12 | unsupported | N/A                      |
-| Kubernetes 1.11 | unsupported | N/A                      |
-| Kubernetes 1.10 | unsupported | N/A                      |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/platform equinix-metal
/exp intermediate
/topology garden seed shoot
/merge squash

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.23 to the extension.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#5102

**Special notes for your reviewer**:
* ✅ ~Depends on #188, hence, PR is in draft state.~
* I have not validated the functionality as follows due to missing test/dev environment:
  * ❔ Create new clusters with versions < 1.23
  * ❔ Create new clusters with version  = 1.23
  * ❔ Upgrade old clusters from version 1.22 to version 1.23
  * ❔ Delete clusters with versions < 1.23
  * ❔ Delete clusters with version  = 1.23

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```feature user
The Equinix Metal extension does now support shoot clusters with Kubernetes version 1.23. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md) before upgrading to 1.23. 
```