### PR TITLE
Only set supported feature gates of kubelet

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -251,13 +252,32 @@ func (e *ensurer) EnsureKubeletConfiguration(_ context.Context, _ gcontext.Garde
 	if new.FeatureGates == nil {
 		new.FeatureGates = make(map[string]bool)
 	}
-	new.FeatureGates["VolumeSnapshotDataSource"] = true
-	new.FeatureGates["CSINodeInfo"] = true
-	new.FeatureGates["CSIDriverRegistry"] = true
+	if err := setFeatureGateIfSupported(new.FeatureGates, "VolumeSnapshotDataSource", kubeletVersion.String()); err != nil {
+		return err
+	}
+	if err := setFeatureGateIfSupported(new.FeatureGates, "CSINodeInfo", kubeletVersion.String()); err != nil {
+		return err
+	}
+	if err := setFeatureGateIfSupported(new.FeatureGates, "CSIDriverRegistry", kubeletVersion.String()); err != nil {
+		return err
+	}
 
 	if version.ConstraintK8sGreaterEqual123.Check(kubeletVersion) {
 		new.EnableControllerAttachDetach = pointer.Bool(true)
 	}
 
+	return nil
+}
+
+func setFeatureGateIfSupported(featureGates map[string]bool, featureGate, version string) error {
+	isSupported, err := kutil.IsFeatureGateSupported(featureGate, version)
+	if err != nil {
+		return err
+	}
+	if isSupported {
+		featureGates[featureGate] = true
+	} else {
+		delete(featureGates, featureGate)
+	}
 	return nil
 }

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -548,7 +548,7 @@ var _ = Describe("Ensurer", func() {
 
 	Describe("#EnsureKubeletConfiguration", func() {
 		DescribeTable("should modify existing elements of kubelet configuration",
-			func(kubeletVersion *semver.Version, enableControllerAttachDetach *bool) {
+			func(kubeletVersion *semver.Version, enableControllerAttachDetach *bool, featureGates map[string]bool) {
 				var (
 					oldKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
 						FeatureGates: map[string]bool{
@@ -556,15 +556,11 @@ var _ = Describe("Ensurer", func() {
 						},
 					}
 					newKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
-						FeatureGates: map[string]bool{
-							"Foo":                      true,
-							"VolumeSnapshotDataSource": true,
-							"CSINodeInfo":              true,
-							"CSIDriverRegistry":        true,
-						},
+						FeatureGates:                 featureGates,
 						EnableControllerAttachDetach: enableControllerAttachDetach,
 					}
 				)
+				newKubeletConfig.FeatureGates["Foo"] = true
 
 				// Create ensurer
 				ensurer := NewEnsurer(logger)
@@ -576,8 +572,16 @@ var _ = Describe("Ensurer", func() {
 				Expect(&kubeletConfig).To(Equal(newKubeletConfig))
 			},
 
-			Entry("kubelet version < 1.23", semver.MustParse("1.22.0"), nil),
-			Entry("kubelet version >= 1.23", semver.MustParse("1.23.0"), pointer.Bool(true)),
+			Entry("kubelet version < 1.23", semver.MustParse("1.22.0"), nil, map[string]bool{}),
+			Entry("kubelet version >= 1.23", semver.MustParse("1.23.0"), pointer.Bool(true), map[string]bool{}),
+			Entry("kubelet version = 1.21", semver.MustParse("1.21.0"), nil, map[string]bool{
+				"VolumeSnapshotDataSource": true,
+			}),
+			Entry("kubelet version < 1.21", semver.MustParse("1.20.0"), nil, map[string]bool{
+				"VolumeSnapshotDataSource": true,
+				"CSINodeInfo":              true,
+				"CSIDriverRegistry":        true,
+			}),
 		)
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/platform equinix-metal

**What this PR does / why we need it**:

Only sets the csi feature gates in the kubelet if they are supported.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes removed feature gates in the Kubelet service for newer versions
```
