### PR TITLE
Add extension identifier with version to Equinix Metal client User-Agent headers

### DIFF
--- a/pkg/equinixmetal/client/client.go
+++ b/pkg/equinixmetal/client/client.go
@@ -15,8 +15,10 @@
 package client
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/gardener/gardener-extension-provider-equinix-metal/pkg/version"
 	"github.com/packethost/packngo"
 )
 
@@ -29,7 +31,9 @@ func NewClient(apiKey string) ClientInterface {
 	token := strings.TrimSpace(apiKey)
 
 	if token != "" {
-		return &eqxmClient{packngo.NewClientWithAuth("gardener", token, nil)}
+		client := packngo.NewClientWithAuth("gardener", token, nil)
+		client.UserAgent = fmt.Sprintf("gardener-extension-provider-equinix-metal/%s %s", version.Version, client.UserAgent)
+		return &eqxmClient{client}
 	}
 
 	return nil

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+// Version of the extension (set during build)
+var Version = "dev"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform equinix-metal

**What this PR does / why we need it**:

Adds an extension identifier with version to Equinix Metal client User-Agent headers, per #222.

**Which issue(s) this PR fixes**:
Fixes #222

**Special notes for your reviewer**:

Similar changes elsewhere: 

* https://github.com/equinix/terraform-provider-equinix/blob/314dead5ac3ec831beb176bc98d1e5c84a80f242/equinix/config.go#L189
* https://github.com/kubernetes-sigs/cluster-api-provider-packet/pull/377/files
* https://github.com/equinix/metal-cli/blob/a5e101858bce400e75c0eee011770e8c75dd35e7/internal/cli/root.go#L78

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adds versioned User-Agent to Equinix Metal Client requests
```
