### PR TITLE
Cleanup scheduler.alpha.kubernetes.io/critical-pod annotations

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -16,9 +16,8 @@ spec:
       role: machine-controller-manager
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
 {{- if .Values.podAnnotations }}
+      annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup
/platform equinix-metal

**What this PR does / why we need it**:
Cleanup `scheduler.alpha.kubernetes.io/critical-pod` annotations

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kubernetes/kubernetes/issues/79548

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
scheduler.alpha.kubernetes.io/critical-pod annotation is removed as pod priority (spec.priorityClassName) is used instead to mark pods as critical
```
