### PR TITLE
Vendor `gardener@1.66.1` and add `ShootSystemComponentsHealthy` to `conditionTypesToRemove`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/gardener/etcd-druid v0.15.3
-	github.com/gardener/gardener v1.66.0
+	github.com/gardener/gardener v1.66.1
 	github.com/gardener/machine-controller-manager v0.45.0
 	github.com/go-logr/logr v1.2.3
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gardener/etcd-druid v0.15.3 h1:IMsJTaUaSOXusfgOOF5GX5eJ0o1CI/9XtKzgxwWJ0Eo=
 github.com/gardener/etcd-druid v0.15.3/go.mod h1:VTxoQXmaE2RSP+LQS5qWUDoXzmdK6xlKLUdFhaGu6KM=
-github.com/gardener/gardener v1.66.0 h1:krDrGx6asbjLBJGI7MtAHTV5NtRk9K3LJy1/4zQS0uU=
-github.com/gardener/gardener v1.66.0/go.mod h1:nS3b9qWHphOkzK3aZZYHSlwKz2qTxcKSQ35iHnk80UY=
+github.com/gardener/gardener v1.66.1 h1:KkaPfT7+w4vCXqTNyZdragpnnC5cYlm7IpdEyC+9Tb4=
+github.com/gardener/gardener v1.66.1/go.mod h1:nS3b9qWHphOkzK3aZZYHSlwKz2qTxcKSQ35iHnk80UY=
 github.com/gardener/hvpa-controller/api v0.5.0 h1:f4F3O7YUrenwh4S3TgPREPiB287JjjUiUL18OqPLyAA=
 github.com/gardener/hvpa-controller/api v0.5.0/go.mod h1:QQl3ELkCaki+8RhXl0FZMfvnm0WCGwGJlGmrxJj6lvM=
 github.com/gardener/machine-controller-manager v0.45.0 h1:rpf0PHRXJMGY93oMruNP+tnMawKJXhhzCACyNJsT8Lo=

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -25,6 +25,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -63,7 +64,10 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
 				HealthCheck:   general.NewSeedDeploymentHealthChecker(equinixmetal.CloudControllerManagerName),
 			},
-		}); err != nil {
+		},
+		// TODO(acumino): Remove this condition in a future release.
+		sets.New[gardencorev1beta1.ConditionType](gardencorev1beta1.ShootSystemComponentsHealthy),
+	); err != nil {
 		return err
 	}
 
@@ -84,7 +88,10 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				ConditionType: string(gardencorev1beta1.ShootEveryNodeReady),
 				HealthCheck:   worker.NewNodesChecker(),
 			},
-		})
+		},
+		// TODO(acumino): Remove this condition in a future release.
+		sets.New[gardencorev1beta1.ConditionType](gardencorev1beta1.ShootSystemComponentsHealthy),
+	)
 }
 
 // AddToManager adds a controller with the default Options.

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/healthcheck/controller.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/healthcheck/controller.go
@@ -31,6 +31,7 @@ import (
 	extensionsconfig "github.com/gardener/gardener/extensions/pkg/apis/config"
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	"github.com/gardener/gardener/pkg/api/extensions"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
 	"github.com/gardener/gardener/pkg/utils"
@@ -76,10 +77,11 @@ type DefaultAddArgs struct {
 // They are used as the .type field of the Condition that the HealthCheck controller writes to the extension resource.
 // The field groupVersionKind stores the GroupVersionKind of the extension resource
 type RegisteredExtension struct {
-	extension            extensionsv1alpha1.Object
-	getExtensionObjFunc  GetExtensionObjectFunc
-	healthConditionTypes []string
-	groupVersionKind     schema.GroupVersionKind
+	extension              extensionsv1alpha1.Object
+	getExtensionObjFunc    GetExtensionObjectFunc
+	healthConditionTypes   []string
+	groupVersionKind       schema.GroupVersionKind
+	conditionTypesToRemove sets.Set[gardencorev1beta1.ConditionType]
 }
 
 // DefaultRegistration configures the default health check NewActuator to execute the provided health checks and adds it to the provided controller-runtime manager.
@@ -93,7 +95,7 @@ type RegisteredExtension struct {
 // custom predicates allow for fine-grained control which resources to watch
 // healthChecks defines the checks to execute mapped to the healthConditionTypes its contributing to (e.g checkDeployment in Seed -> ControlPlaneHealthy).
 // register returns a runtime representation of the extension resource to register it with the controller-runtime
-func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, getExtensionObjListFunc GetExtensionObjectListFunc, getExtensionObjFunc GetExtensionObjectFunc, mgr manager.Manager, opts DefaultAddArgs, customPredicates []predicate.Predicate, healthChecks []ConditionTypeToHealthCheck) error {
+func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, getExtensionObjListFunc GetExtensionObjectListFunc, getExtensionObjFunc GetExtensionObjectFunc, mgr manager.Manager, opts DefaultAddArgs, customPredicates []predicate.Predicate, healthChecks []ConditionTypeToHealthCheck, conditionTypesToRemove sets.Set[gardencorev1beta1.ConditionType]) error {
 	predicates := append(DefaultPredicates(), customPredicates...)
 	opts.Controller.RecoverPanic = pointer.Bool(true)
 
@@ -105,7 +107,7 @@ func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, get
 		GetExtensionObjListFunc: getExtensionObjListFunc,
 	}
 
-	if err := args.RegisterExtension(getExtensionObjFunc, getHealthCheckTypes(healthChecks), kind); err != nil {
+	if err := args.RegisterExtension(getExtensionObjFunc, getHealthCheckTypes(healthChecks), kind, conditionTypesToRemove); err != nil {
 		return err
 	}
 
@@ -123,17 +125,18 @@ func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, get
 // The controller writes the healthCheckTypes as a condition.type into the extension resource.
 // To contribute to the Shoot's health, the Gardener checks each extension for a Health Condition Type of SystemComponentsHealthy, EveryNodeReady, ControlPlaneHealthy.
 // However extensions are free to choose any healthCheckType
-func (a *AddArgs) RegisterExtension(getExtensionObjFunc GetExtensionObjectFunc, conditionTypes []string, kind schema.GroupVersionKind) error {
+func (a *AddArgs) RegisterExtension(getExtensionObjFunc GetExtensionObjectFunc, conditionTypes []string, kind schema.GroupVersionKind, conditionTypesToRemove sets.Set[gardencorev1beta1.ConditionType]) error {
 	acc, err := extensions.Accessor(getExtensionObjFunc())
 	if err != nil {
 		return err
 	}
 
 	a.registeredExtension = &RegisteredExtension{
-		extension:            acc,
-		healthConditionTypes: conditionTypes,
-		groupVersionKind:     kind,
-		getExtensionObjFunc:  getExtensionObjFunc,
+		extension:              acc,
+		healthConditionTypes:   conditionTypes,
+		groupVersionKind:       kind,
+		getExtensionObjFunc:    getExtensionObjFunc,
+		conditionTypesToRemove: conditionTypesToRemove,
 	}
 	return nil
 }

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/healthcheck/reconciler.go
@@ -112,6 +112,17 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	// cleanup conditions from extension status
+	if len(r.registeredExtension.conditionTypesToRemove) > 0 {
+		var newConditions []gardencorev1beta1.Condition
+		for _, condition := range extension.GetExtensionStatus().GetConditions() {
+			if !r.registeredExtension.conditionTypesToRemove.Has(condition.Type) {
+				newConditions = append(newConditions, condition)
+			}
+		}
+		extension.GetExtensionStatus().SetConditions(newConditions)
+	}
+
 	if extensionscontroller.IsHibernationEnabled(cluster) {
 		var conditions []condition
 		for _, healthConditionType := range r.registeredExtension.healthConditionTypes {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -63,7 +63,7 @@ github.com/fsnotify/fsnotify
 # github.com/gardener/etcd-druid v0.15.3
 ## explicit; go 1.19
 github.com/gardener/etcd-druid/api/v1alpha1
-# github.com/gardener/gardener v1.66.0
+# github.com/gardener/gardener v1.66.1
 ## explicit; go 1.20
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform equinix-metal

**What this PR does / why we need it**:
For the reasoning, please check https://github.com/gardener/gardener/issues/6775#issuecomment-1432816749 and https://github.com/gardener/gardener/pull/7660.
We need to add `ShootSystemComponentsHealthy` to conditionTypesToRemove.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6775

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The stale healthcheck conditions from the extension are now properly cleaned up.
```

```
The following dependency is updated:
- github.com/gardener/gardener: v1.66.0 -> v1.66.1
```