### PR TITLE
Switched from DockerHub to Gardener GCR

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -5,7 +5,7 @@ images:
   tag: "v2.11.0"
 - name: cloud-controller-manager
   sourceRepository: github.com/equinix/cloud-provider-equinix-metal
-  repository: docker.io/equinix/cloud-provider-equinix-metal
+  repository: eu.gcr.io/gardener-project/3rd/equinix/cloud-provider-equinix-metal
   tag: v3.5.0
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
@@ -17,7 +17,7 @@ images:
   tag: "v0.5.0"
 - name: metabot
   sourceRepository: github.com/packethost/metabot
-  repository: packethost/metabot
+  repository: eu.gcr.io/gardener-project/3rd/packethost/metabot
   tag: v1.0.0
 - name: metallb-controller
   sourceRepository: github.com/metallb/metallb


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR is needed to support IPv6 single stack and avoid DockerHub pull limits as it uses copied images from Gardener GCR instead.
Part of https://github.com/gardener/ci-infra/issues/619

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Switched images from DockerHub to copies in Gardener GCR
```
