### PR TITLE
Use generic kubeconfig in ccm

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-provider-equinix-metal/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
               items:
               - key: kubeconfig
                 path: kubeconfig
-              name: generic-token-kubeconfig
+              name: {{ .Values.global.genericTokenKubeconfigSecretName }}
               optional: false
           - secret:
               items:

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -150,6 +150,9 @@ func getControlPlaneChartValues(
 	error,
 ) {
 	values := map[string]interface{}{
+		"global": map[string]interface{}{
+			"genericTokenKubeconfigSecretName": extensionscontroller.GenericTokenKubeconfigSecretNameFromCluster(cluster),
+		},
 		"cloud-provider-equinix-metal": map[string]interface{}{
 			"replicas":    extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 			"clusterName": cp.Namespace,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -79,6 +79,9 @@ var _ = Describe("ValuesProvider", func() {
 		}
 
 		controlPlaneChartValues = map[string]interface{}{
+			"global": map[string]interface{}{
+				"genericTokenKubeconfigSecretName": genericTokenKubeconfigSecretName,
+			},
 			"cloud-provider-equinix-metal": map[string]interface{}{
 				"replicas":    1,
 				"clusterName": namespace,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/platform equinix-metal

**What this PR does / why we need it**:

Fixes a bug that causes the ccm to not be correctly deployed due to a missing generic kubeconfig.
The currently used kubeconfig is not deployed anymore since newer Gardener versions.

This PR now injects the correct dynamic kubeconfig similar to the other extensions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes a bug in the CCM deployment that caused it to not be correctly deployed due to an outdated secret reference in newer Gardener versions.
```
