### PR TITLE
Add support to boot images via iPXE

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -20,7 +20,12 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 providerSpec:
   projectID: {{ $machineClass.projectID }}
+  {{- if $machineClass.OS }}
   OS: {{ $machineClass.OS }}
+  {{- end }}
+  {{- if $machineClass.ipxeScriptUrl }}
+  ipxeScriptUrl: {{ $machineClass.ipxeScriptUrl }}
+  {{- end }}
   billingCycle: {{ $machineClass.billingCycle }}
   machineType: {{ $machineClass.machineType }}
   sshKeys:

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -3,7 +3,8 @@ machineClasses:
 # labels:
 #   foo: bar
   projectID: abcd-1234-fff
-  OS: alpine_3
+#  OS: alpine_3
+#  ipxeScriptUrl: https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_packet.ipxe
   billingCycle: hourly
   metro: ny
   facilities:

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -45,12 +45,18 @@ spec:
       versions:
       - version: 0.0.0-stable
         id: flatcar_stable
+      - version: 3510.2.2
+        ipxeScriptUrl: https://stable.release.flatcar-linux.net/amd64-usr/3510.2.2/flatcar_production_packet.ipxe
 ```
 
 ## `CloudProfileConfig`
 
 The cloud profile configuration contains information about the real machine image IDs in the Equinix Metal environment (IDs).
 You have to map every version that you specify in `.spec.machineImages[].versions` here such that the Equinix Metal extension knows the ID for every version you want to offer.
+
+Equinix Metal supports two different options to specify the image:
+1. Supported Operating System: Images that are provided by Equinix Metal. They are referenced by their ID (`slug`). See (Operating Systems Reference)[https://deploy.equinix.com/developers/docs/metal/operating-systems/supported/#operating-systems-reference] for all supported operating system and their ids.
+2. Custom iPXE Boot: Equinix Metal supports passing custom iPXE scripts during provisioning, which allows you to install a custom operating system manually. This is useful if you want to have a custom image or want to pin to a specific version. See [Custom iPXE Boot](https://deploy.equinix.com/developers/docs/metal/operating-systems/custom-ipxe/#provisioning-with-custom-ipxe) for details.
 
 An example `CloudProfileConfig` for the Equinix Metal extension looks as follows:
 
@@ -62,6 +68,8 @@ machineImages:
   versions:
   - version: 0.0.0-stable
     id: flatcar_stable
+  - version: 3510.2.2
+    ipxeScriptUrl: https://stable.release.flatcar-linux.net/amd64-usr/3510.2.2/flatcar_production_packet.ipxe
 ```
 
 > NOTE: `CloudProfileConfig` is not a Custom Resource, so you cannot create it directly.

--- a/example/26-cloudprofile.yaml
+++ b/example/26-cloudprofile.yaml
@@ -43,6 +43,8 @@ spec:
       versions:
       - version: 0.0.0-stable
         id: flatcar_stable
+      - version: 3510.2.2
+        ipxeScriptUrl: https://stable.release.flatcar-linux.net/amd64-usr/3510.2.2/flatcar_production_packet.ipxe
     - name: ubuntu
       versions:
       - version: "20.04"

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -22,10 +22,12 @@ spec:
         apiVersion: equinixmetal.provider.extensions.gardener.cloud/v1alpha1
         kind: CloudProfileConfig
         machineImages:
-        - name: coreos
+        - name: flatcar
           versions:
           - version: 2023.5.0
             id: eqxm-image-id
+          - version: 3510.2.2
+            ipxeScriptUrl: https://stable.release.flatcar-linux.net/amd64-usr/3510.2.2/flatcar_production_packet.ipxe
   seed:
     apiVersion: core.gardener.cloud/v1beta1
     kind: Seed

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -310,7 +310,20 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ID is the id of the image.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ipxeScriptUrl</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IPXEScriptURL is url to point to a IPXE script.</p>
 </td>
 </tr>
 </tbody>
@@ -351,7 +364,20 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ID is the id of the image.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ipxeScriptUrl</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IPXEScriptURL is url to point to a IPXE script.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/equinixmetal/helper/helper.go
+++ b/pkg/apis/equinixmetal/helper/helper.go
@@ -35,7 +35,7 @@ func FindMachineImage(machineImages []api.MachineImage, name, version string) (*
 // FindImageFromCloudProfile takes a list of machine images, and the desired image name and version. It tries
 // to find the image with the given name and version in the desired cloud profile. If it cannot be found then an error
 // is returned.
-func FindImageFromCloudProfile(cloudProfileConfig *api.CloudProfileConfig, imageName, imageVersion string) (string, error) {
+func FindImageFromCloudProfile(cloudProfileConfig *api.CloudProfileConfig, imageName, imageVersion string) (*api.MachineImageVersion, error) {
 	if cloudProfileConfig != nil {
 		for _, machineImage := range cloudProfileConfig.MachineImages {
 			if machineImage.Name != imageName {
@@ -43,11 +43,11 @@ func FindImageFromCloudProfile(cloudProfileConfig *api.CloudProfileConfig, image
 			}
 			for _, version := range machineImage.Versions {
 				if imageVersion == version.Version {
-					return version.ID, nil
+					return &version, nil
 				}
 			}
 		}
 	}
 
-	return "", fmt.Errorf("could not find an image for name %q in version %q", imageName, imageVersion)
+	return nil, fmt.Errorf("could not find an image for name %q in version %q", imageName, imageVersion)
 }

--- a/pkg/apis/equinixmetal/helper/helper_test.go
+++ b/pkg/apis/equinixmetal/helper/helper_test.go
@@ -45,8 +45,8 @@ var _ = Describe("Helper", func() {
 			cfg.MachineImages = profileImages
 			image, err := FindImageFromCloudProfile(cfg, imageName, version)
 
-			Expect(image).To(Equal(expectedImage))
 			if expectedImage != "" {
+				Expect(image.ID).To(Equal(expectedImage))
 				Expect(err).NotTo(HaveOccurred())
 			} else {
 				Expect(err).To(HaveOccurred())

--- a/pkg/apis/equinixmetal/types_cloudprofile.go
+++ b/pkg/apis/equinixmetal/types_cloudprofile.go
@@ -43,4 +43,6 @@ type MachineImageVersion struct {
 	Version string
 	// ID is the id of the image.
 	ID string
+	// IPXEScriptURL is url to point to a IPXE script.
+	IPXEScriptURL string
 }

--- a/pkg/apis/equinixmetal/types_worker.go
+++ b/pkg/apis/equinixmetal/types_worker.go
@@ -54,4 +54,6 @@ type MachineImage struct {
 	Version string
 	// ID is the id of the image.
 	ID string
+	// IPXEScriptURL is url to point to a IPXE script.
+	IPXEScriptURL string
 }

--- a/pkg/apis/equinixmetal/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/equinixmetal/v1alpha1/types_cloudprofile.go
@@ -43,5 +43,9 @@ type MachineImageVersion struct {
 	// Version is the version of the image.
 	Version string `json:"version"`
 	// ID is the id of the image.
-	ID string `json:"id"`
+	// +optional
+	ID string `json:"id,omitempty"`
+	// IPXEScriptURL is url to point to a IPXE script.
+	// +optional
+	IPXEScriptURL string `json:"ipxeScriptUrl,omitempty"`
 }

--- a/pkg/apis/equinixmetal/v1alpha1/types_worker.go
+++ b/pkg/apis/equinixmetal/v1alpha1/types_worker.go
@@ -58,5 +58,9 @@ type MachineImage struct {
 	// Version is the logical version of the machine image.
 	Version string `json:"version"`
 	// ID is the id of the image.
-	ID string `json:"id"`
+	// +optional
+	ID string `json:"id,omitempty"`
+	// IPXEScriptURL is url to point to a IPXE script.
+	// +optional
+	IPXEScriptURL string `json:"ipxeScriptUrl,omitempty"`
 }

--- a/pkg/apis/equinixmetal/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/equinixmetal/v1alpha1/zz_generated.conversion.go
@@ -209,6 +209,7 @@ func autoConvert_v1alpha1_MachineImage_To_equinixmetal_MachineImage(in *MachineI
 	out.Name = in.Name
 	out.Version = in.Version
 	out.ID = in.ID
+	out.IPXEScriptURL = in.IPXEScriptURL
 	return nil
 }
 
@@ -221,6 +222,7 @@ func autoConvert_equinixmetal_MachineImage_To_v1alpha1_MachineImage(in *equinixm
 	out.Name = in.Name
 	out.Version = in.Version
 	out.ID = in.ID
+	out.IPXEScriptURL = in.IPXEScriptURL
 	return nil
 }
 
@@ -232,6 +234,7 @@ func Convert_equinixmetal_MachineImage_To_v1alpha1_MachineImage(in *equinixmetal
 func autoConvert_v1alpha1_MachineImageVersion_To_equinixmetal_MachineImageVersion(in *MachineImageVersion, out *equinixmetal.MachineImageVersion, s conversion.Scope) error {
 	out.Version = in.Version
 	out.ID = in.ID
+	out.IPXEScriptURL = in.IPXEScriptURL
 	return nil
 }
 
@@ -243,6 +246,7 @@ func Convert_v1alpha1_MachineImageVersion_To_equinixmetal_MachineImageVersion(in
 func autoConvert_equinixmetal_MachineImageVersion_To_v1alpha1_MachineImageVersion(in *equinixmetal.MachineImageVersion, out *MachineImageVersion, s conversion.Scope) error {
 	out.Version = in.Version
 	out.ID = in.ID
+	out.IPXEScriptURL = in.IPXEScriptURL
 	return nil
 }
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -102,23 +102,25 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			return err
 		}
 
-		machineImageID, err := w.findMachineImage(pool.MachineImage.Name, pool.MachineImage.Version)
+		machineImage, err := w.findMachineImage(pool.MachineImage.Name, pool.MachineImage.Version)
 		if err != nil {
 			return err
 		}
 		machineImages = appendMachineImage(machineImages, api.MachineImage{
-			Name:    pool.MachineImage.Name,
-			Version: pool.MachineImage.Version,
-			ID:      machineImageID,
+			Name:          pool.MachineImage.Name,
+			Version:       pool.MachineImage.Version,
+			ID:            machineImage.ID,
+			IPXEScriptURL: machineImage.IPXEScriptURL,
 		})
 
 		machineClassSpec := map[string]interface{}{
-			"OS":           machineImageID,
-			"projectID":    string(credentials.ProjectID),
-			"billingCycle": "hourly",
-			"machineType":  pool.MachineType,
-			"metro":        w.worker.Spec.Region,
-			"sshKeys":      []string{infrastructureStatus.SSHKeyID},
+			"OS":            machineImage.ID,
+			"ipxeScriptUrl": machineImage.IPXEScriptURL,
+			"projectID":     string(credentials.ProjectID),
+			"billingCycle":  "hourly",
+			"machineType":   pool.MachineType,
+			"metro":         w.worker.Spec.Region,
+			"sshKeys":       []string{infrastructureStatus.SSHKeyID},
 			"tags": []string{
 				fmt.Sprintf("kubernetes.io/cluster/%s", w.worker.Namespace),
 				"kubernetes.io/role/node",

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -281,12 +281,13 @@ var _ = Describe("Machines", func() {
 
 				BeforeEach(func() {
 					defaultMachineClass = map[string]interface{}{
-						"OS":           machineImage,
-						"projectID":    projectID,
-						"billingCycle": "hourly",
-						"machineType":  machineType,
-						"metro":        region,
-						"sshKeys":      []string{sshKeyID},
+						"OS":            machineImage,
+						"ipxeScriptUrl": "",
+						"projectID":     projectID,
+						"billingCycle":  "hourly",
+						"machineType":   machineType,
+						"metro":         region,
+						"sshKeys":       []string{sshKeyID},
 						"tags": []string{
 							fmt.Sprintf("kubernetes.io/cluster/%s", namespace),
 							"kubernetes.io/role/node",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/platform equinix-metal

**What this PR does / why we need it**:

Adds the ability to boot custom images via iPXE (https://deploy.equinix.com/developers/docs/metal/operating-systems/custom-ipxe/).
This is useful if
- a different os than the officially maintined images should be used
- a specific version of a OS should be pinned. This is needed because for example for Flatcar, Equinix is currently
  - rarely updating their channels (stable, beta, ...)
  - you are stick to the version Equinix chooses
  - the used version is intransparent
  - The version differs from DC to DC

**Special notes for your reviewer**:

Requires https://github.com/gardener/machine-controller-manager-provider-equinix-metal/pull/18 to be merged and released.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add support to specify custom images via iPXE boot.
```
