### PR TITLE
Update metallb images to use v0.12.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -22,8 +22,8 @@ images:
 - name: metallb-controller
   sourceRepository: github.com/metallb/metallb
   repository: quay.io/metallb/controller
-  tag: v0.9.5
+  tag: v0.12.1
 - name: metallb-speaker
   sourceRepository: github.com/metallb/metallb
   repository: quay.io/metallb/speaker
-  tag: v0.9.5
+  tag: v0.12.1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform equinix-metal

**What this PR does / why we need it**:
The equinix metallb only supports metallb versions > 11.0 see their [docs](https://github.com/equinix/cloud-provider-equinix-metal#metallb).
Currently we use v0.9.2 which causes an invalid config and therefore the BGP routes not to the updated correctly:
```
could not parse config: yaml: unmarshal errors:\n  line 37: field source-address not found in type config.peer
``` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
MetalLb has been updated to version 0.12.1 which fixes a compatibility issue with the Equinix CCM.
```
