### PR TITLE
Move CleanupMachineDependencies to PostReconcileHook

### DIFF
--- a/pkg/controller/worker/machine_dependencies.go
+++ b/pkg/controller/worker/machine_dependencies.go
@@ -35,11 +35,7 @@ import (
 	eqxcmclient "github.com/gardener/gardener-extension-provider-equinix-metal/pkg/equinixmetal/client"
 )
 
-func (w *workerDelegate) DeployMachineDependencies(_ context.Context) error {
-	return nil
-}
-
-func (w *workerDelegate) CleanupMachineDependencies(ctx context.Context) error {
+func (w *workerDelegate) PostReconcileHook(ctx context.Context) error {
 	const (
 		nodeNetworkEnvVarKey                  = "NODE_NETWORK"
 		equinixMetalPrivateNetworkAnnotations = "metal.equinix.com/network-4-private"
@@ -150,11 +146,6 @@ func (w *workerDelegate) CleanupMachineDependencies(ctx context.Context) error {
 
 // PreReconcileHook implements genericactuator.WorkerDelegate.
 func (w *workerDelegate) PreReconcileHook(_ context.Context) error {
-	return nil
-}
-
-// PostReconcileHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PostReconcileHook(_ context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug
/platform equinix-metal

**What this PR does / why we need it**:

The `CleanupMachineDependencies` function got already deprecated in https://github.com/gardener/gardener/pull/6290 and then completely removed in https://github.com/gardener/gardener/pull/7600.

The `CleanupMachineDependencies` is since a while not called anymore which causes the vpn server not correctly work anymore.

This PR migrates the `CleanupMachineDependencies` to the new `PostReconcileHook` function.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes are bug in the worker reconciler where the node network was not injected. This caused the vpn-server-pod to not work anymore.
```
