### PR TITLE
Fix unknown autoscaler type

### DIFF
--- a/cmd/gardener-extension-provider-equinix-metal/app/app.go
+++ b/cmd/gardener-extension-provider-equinix-metal/app/app.go
@@ -31,6 +31,7 @@ import (
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	eqxminstall "github.com/gardener/gardener-extension-provider-equinix-metal/pkg/apis/equinixmetal/install"
@@ -154,6 +155,9 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not update manager scheme: %w", err)
 			}
 			if err := druidv1alpha1.AddToScheme(scheme); err != nil {
+				return fmt.Errorf("could not update manager scheme: %w", err)
+			}
+			if err := autoscalingv1.AddToScheme(scheme); err != nil {
 				return fmt.Errorf("could not update manager scheme: %w", err)
 			}
 			if err := machinev1alpha1.AddToScheme(scheme); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/platform equinix-metal

**What this PR does / why we need it**:

The current controller fails to start due to an unknown vertical autoscaler crd.
```
{"level":"error","ts":"2023-09-07T12:41:19.282Z","msg":"error executing the main controller command","error":"could not add webhooks to manager: could not create webhooks: could not get GroupVersionKind from object &{{ } {      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []} {nil <nil> <nil> []} {<nil> []}}: no kind is registered for the type v1.VerticalPodAutoscaler in scheme \"k8s.io/client-go/kubernetes/scheme/register.go:79\"","stacktrace":"main.main\n\t/go/src/github.com/gardener/gardener-extension-provider-equinix-metal/cmd/gardener-extension-provider-equinix-metal/main.go:32\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}
```

The type are introduced in this [PR](https://github.com/gardener/gardener-extension-provider-equinix-metal/pull/275) but never added to the known types in the controller.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
