### PR TITLE
Drop support for Shoots with Kubernetes version < 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.26 | untested    | N/A                      |
 | Kubernetes 1.25 | untested    | N/A                      |
 | Kubernetes 1.24 | untested    | N/A                      |
-| Kubernetes 1.23 | untested    | N/A                      |
-| Kubernetes 1.22 | untested    | N/A                      |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -17,9 +17,9 @@ spec:
   type: equinixmetal
   kubernetes:
     versions:
-    - version: 1.24.2
-    - version: 1.23.7
-    - version: 1.22.15
+    - version: 1.27.2
+    - version: 1.26.7
+    - version: 1.25.10
       #expirationDate: "2023-03-15T23:59:59Z"
   machineImages:
   - name: flatcar

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -138,7 +138,7 @@ spec:
   networking:
     type: calico
   kubernetes:
-    version: 1.23.2
+    version: 1.27.2
   maintenance:
     autoUpdate:
       kubernetesVersion: true

--- a/example/26-cloudprofile.yaml
+++ b/example/26-cloudprofile.yaml
@@ -6,9 +6,9 @@ spec:
   type: equinixmetal
   kubernetes:
     versions:
-    - version: 1.24.2
-    - version: 1.23.7
-    - version: 1.22.15
+    - version: 1.27.2
+    - version: 1.26.7
+    - version: 1.25.10
       #expirationDate: "2023-03-15T23:59:59Z"
   machineImages:
   - name: flatcar


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup
/platform equinix-metal

**What this PR does / why we need it**:
Drop support for kubernetes < 1.24 for Equinix metal extension provider

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8405

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`provider-equinix-metal` no longer supports Shoots or Seeds with Кubernetes version < 1.24.
```
