### PR TITLE
Read new `.spec.pools[].userDataSecretRef` field for worker pool user data

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -87,6 +87,11 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			IPXEScriptURL: machineImage.IPXEScriptURL,
 		})
 
+		userData, err := worker.FetchUserData(ctx, w.client, w.worker.Namespace, pool)
+		if err != nil {
+			return err
+		}
+
 		machineClassSpec := map[string]interface{}{
 			"OS":            machineImage.ID,
 			"ipxeScriptUrl": machineImage.IPXEScriptURL,
@@ -100,7 +105,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"kubernetes.io/role/node",
 			},
 			"secret": map[string]interface{}{
-				"cloudConfig": string(pool.UserData),
+				"cloudConfig": string(userData),
 			},
 			"credentialsSecretRef": map[string]interface{}{
 				"name":      w.worker.Spec.SecretRef.Name,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
This extension now makes use of the new `.spec.pools[].userDataSecretRef` field (introduced with https://github.com/gardener/gardener/pull/9722 and available from `gardener/gardener@v1.95+`) to get to the worker pool user data.
Similar to https://github.com/gardener/gardener/pull/9722/commits/6132277453085bb76402861e8d3cb41e896167b0

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9545

**Special notes for your reviewer**:
/cc @kon-angelo 

> [!NOTE]
> Build on top of https://github.com/gardener/gardener-extension-provider-gcp/pull/763, only the last commit is relevant.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
This extension now makes use of the new `.spec.pools[].userDataSecretRef` field to get to the worker pool user data.
```
