### PR TITLE
Publish Helm charts as OCI artifacts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,4 +1,16 @@
 gardener-extension-provider-equinix-metal:
+  templates: 
+    helmcharts:
+    - &provider-equinix-metal
+      name: provider-equinix-metal
+      dir: charts/gardener-extension-provider-equinix-metal
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-provider-equinix-metal.repository
+        attribute: image.repository
+      - ref: ocm-resource:gardener-extension-provider-equinix-metal.tag
+        attribute: image.tag
+
   template: 'default'
   base_definition:
     repo: ~
@@ -20,11 +32,15 @@ gardener-extension-provider-equinix-metal:
         draft_release: ~
         options:
           public_build_logs: true
+        helmcharts:
+          - *provider-equinix-metal
     pull-request:
       traits:
         pull-request: ~
         options:
           public_build_logs: true
+        helmcharts:
+          - *provider-equinix-metal
     release:
       traits:
         version:
@@ -47,3 +63,6 @@ gardener-extension-provider-equinix-metal:
               tag_as_latest: true
               registry: 'gcp-opensource'
               image: 'europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/provider-equinix-metal'
+          helmcharts:
+          - <<: *provider-equinix-metal
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement
/platform equinix-metal

**What this PR does / why we need it**:
We should start publishing Helm charts as OCI artifacts that we can deploy them as `Extension` in the future (see https://github.com/gardener/gardener/issues/9635).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Helm charts of extension and admission controller are published as OCI artifacts now.
```
