### PR TITLE
Specifiy helmcharts as property of the `publish` trait

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,5 +1,5 @@
 gardener-extension-provider-equinix-metal:
-  templates: 
+  templates:
     helmcharts:
     - &provider-equinix-metal
       name: provider-equinix-metal
@@ -32,15 +32,17 @@ gardener-extension-provider-equinix-metal:
         draft_release: ~
         options:
           public_build_logs: true
-        helmcharts:
-          - *provider-equinix-metal
+        publish:
+          helmcharts:
+          - <<: *provider-equinix-metal
     pull-request:
       traits:
         pull-request: ~
         options:
           public_build_logs: true
-        helmcharts:
-          - *provider-equinix-metal
+        publish:
+          helmcharts:
+          - <<: *provider-equinix-metal
     release:
       traits:
         version:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO
/platform equinix-metal

**What this PR does / why we need it**:
Currently, the pipeline replication is broken because the `helmcharts` property is defined at the wrong level (it has to be defined as property of the `publish` trait).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
