### PR TITLE
feat(ensurer): add additional units and files for lvm disk provisioni…

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ certain conditions:
 
 Feedback and contributions are always welcome. Please report bugs or suggestions as [GitHub issues](https://github.com/gardener/gardener-extension-provider-equinix-metal/issues) or join our [Slack channel #gardener](https://kubernetes.slack.com/messages/gardener) (please invite yourself to the Kubernetes workspace [here](http://slack.k8s.io)).
 
+## Contributing
+We appreciate contributions, but you need to follow certain processes:
+
+### Process
+To contribute, please open an issue, follow the template and describe what
+you'd like to do.
+
+For smaller fixes, you can usually start work already, for bigger changes,
+please wait for a maintainer to get back to you on the issue.
+
+### Technical
+Please make sure that your code is tested.
+
+Make sure to run `make generate` and add the generated files to your commit as 
+otherwise the tests will most likely fail.
+
 ## Learn more!
 
 Please find further resources about out project here:

--- a/README.md
+++ b/README.md
@@ -52,22 +52,6 @@ certain conditions:
 
 Feedback and contributions are always welcome. Please report bugs or suggestions as [GitHub issues](https://github.com/gardener/gardener-extension-provider-equinix-metal/issues) or join our [Slack channel #gardener](https://kubernetes.slack.com/messages/gardener) (please invite yourself to the Kubernetes workspace [here](http://slack.k8s.io)).
 
-## Contributing
-We appreciate contributions, but you need to follow certain processes:
-
-### Process
-To contribute, please open an issue, follow the template and describe what
-you'd like to do.
-
-For smaller fixes, you can usually start work already, for bigger changes,
-please wait for a maintainer to get back to you on the issue.
-
-### Technical
-Please make sure that your code is tested.
-
-Make sure to run `make generate` and add the generated files to your commit as 
-otherwise the tests will most likely fail.
-
 ## Learn more!
 
 Please find further resources about out project here:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Static code checks and tests can be executed by running `make verify`. We are us
 You can use all available disks on your Equinix instance, but only under 
 certain conditions:
 * You must use Flatcar
-* You must have a homogenous worker pool
+* You must have a homogenous worker pool (all workers use the same OS and 
+  container engine)
 * You must set any value for `DataVolume`
 
 ## Feedback and Support

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ You can run the controller locally on your machine by executing `make start`.
 
 Static code checks and tests can be executed by running `make verify`. We are using Go modules for Golang package dependency management and [Ginkgo](https://github.com/onsi/ginkgo)/[Gomega](https://github.com/onsi/gomega) for testing.
 
+## Caveats
+You can use all available disks on your Equinix instance, but only under 
+certain conditions:
+* You must use Flatcar
+* You must have a homogenous worker pool
+* You must set any value for `DataVolume`
+
 ## Feedback and Support
 
 Feedback and contributions are always welcome. Please report bugs or suggestions as [GitHub issues](https://github.com/gardener/gardener-extension-provider-equinix-metal/issues) or join our [Slack channel #gardener](https://kubernetes.slack.com/messages/gardener) (please invite yourself to the Kubernetes workspace [here](http://slack.k8s.io)).

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -193,7 +193,7 @@ func (e *ensurer) EnsureAdditionalProvisionUnits(ctx context.Context, gctx gcont
 			// fail if multiple OSes are used
 			operatingsystems[worker.Machine.Image.Name]++
 			if len(operatingsystems) > 1 {
-				return fmt.Errorf("multiple operatingsystems used")
+				return fmt.Errorf("multiple operatingsystems used: %v; Only one allowed", operatingsystems)
 			}
 			switch worker.Machine.Image.Name {
 			case "flatcar":
@@ -234,7 +234,7 @@ func (e *ensurer) EnsureAdditionalProvisionFiles(ctx context.Context, gctx gcont
 			// fail if multiple OSes are used
 			operatingsystems[worker.Machine.Image.Name]++
 			if len(operatingsystems) > 1 {
-				return fmt.Errorf("multiple operatingsystems used")
+				return fmt.Errorf("multiple operatingsystems used: %v; Only one allowed", operatingsystems)
 			}
 
 			switch worker.Machine.Image.Name {

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -187,7 +187,7 @@ func (e *ensurer) EnsureAdditionalProvisionUnits(ctx context.Context, gctx gcont
         [Install]
         WantedBy=local-fs.target
 `
-	var operatingsystems map[string]int
+	operatingsystems := make(map[string]int)
 	for _, worker := range cluster.Shoot.Spec.Provider.Workers {
 		if worker.DataVolumes != nil {
 			// fail if multiple OSes are used
@@ -226,7 +226,7 @@ func (e *ensurer) EnsureAdditionalProvisionFiles(ctx context.Context, gctx gcont
 		return err
 	}
 
-	var operatingsystems map[string]int
+	operatingsystems := make(map[string]int)
 	for _, worker := range cluster.Shoot.Spec.Provider.Workers {
 		// if any worker is having any value set for `DataVolume`
 		// this script creates a lvm from all remaining non-boot disks.

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -7,6 +7,7 @@ package controlplane
 import (
 	"context"
 	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/coreos/go-systemd/v22/unit"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"


### PR DESCRIPTION
…ng on flatcar

**How to categorize this PR?**
/area storage
/kind enhancement
/platform equinix-metal

**What this PR does / why we need it**:
This is PR allows to use all volumes for containerd, using LVM. 

As instances on Equinix are preconfigured in terms of disks, operators want to be able to use all disks and not constantly run out of space, while there's theoretically multiple untouched disks left.

This PR creates a unit that executes a script to use LVM to make use of all volumes and another unit to then mount the new volume to `/var/lib/containerd`. 

**Special notes for your reviewer**:
This only applies to flatcar linux but using a switch/case statement, if more distros will be added in the future.
The code has to depend on the distro, as potentially every OS does things differently.

LVM on flatcar hasn't be documented but working --> https://github.com/flatcar/flatcar-website/pull/362
**Release note**:
```feature operator
The provider-equinix-metal extension now allows to use all volumes of an equinix instance under the followibng conditions:
* use flatcar linux
* use only one OS
* use containerd as container engine
```
