### PR TITLE
docs: Fix reference to shoot operations documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -486,7 +486,7 @@ visible Git diff).
 
 #### Retrying operations
 
-If shoot creation operations fail, you can restart them. See [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_operations.md). For example, to retry a failed shoot creation:
+If shoot creation operations fail, you can restart them. See [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_operations.md). For example, to retry a failed shoot creation:
 
 ```
 $ kubectl -n garden-em annotate shoot em-test gardener.cloud/operation=retry


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup
/platform equinix-metal

**What this PR does / why we need it**:

The file has been moved with this PR: https://github.com/gardener/gardener/pull/10436

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

_n.a._

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
Fixed a reference to the shoot operations documentation.
```
