### PR TITLE
fix(ensurer): add missing equal sign

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -410,7 +410,7 @@ func hasVolume(ctx context.Context, gctx gcontext.GardenContext) (bool, error) {
 
 // ensureKubeletRootDirCommandLineArg adds a flag to the kubelet to use /var/lib/containerd which is what where we also mount the created LVM if `volume` is set in the worker config
 func ensureKubeletRootDirCommandLineArg(command []string) []string {
-	return extensionswebhook.EnsureStringWithPrefix(command, "--root-dir", "/var/lib/containerd")
+	return extensionswebhook.EnsureStringWithPrefix(command, "--root-dir=", "/var/lib/containerd")
 }
 
 func ensureKubeletCommandLineArgs(command []string) []string {


### PR DESCRIPTION
**How to categorize this PR?**
/area storage
/kind bug
/platform equinix-metal

**What this PR does / why we need it**:
missing `=` in the kubelet args causes kubelet to crash

**Release note**:
```fix operator
* fix kubelet args
```