### PR TITLE
fix: change strategicMergeFrom to MergeFrom for CRD

### DIFF
--- a/pkg/controller/worker/machine_dependencies.go
+++ b/pkg/controller/worker/machine_dependencies.go
@@ -93,7 +93,7 @@ func (w *workerDelegate) PostReconcileHook(ctx context.Context) error {
 		controlplane.ParseJoinedNetwork(*infra.Status.NodesCIDR).Equal(targetCIDRs) {
 
 		var (
-			patch         = client.StrategicMergeFrom(infra.DeepCopy())
+			patch         = client.MergeFrom(infra.DeepCopy())
 			joinedNetwork = controlplane.JoinedNetworksCidr(targetCIDRs)
 		)
 


### PR DESCRIPTION
**How to categorize this PR?**
/area storage
/kind bug
/platform equinix-metal

**What this PR does / why we need it**:
CRDs don't allow `StrategicMergeFrom`, changing this to `MergeFrom` in post reconcile hook

**Release note**:
```fix operator
* fix post reconcile hook
```
