### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.31 | untested    | N/A                      |
 | Kubernetes 1.30 | untested    | N/A                      |
 | Kubernetes 1.29 | untested    | N/A                      |
-| Kubernetes 1.28 | untested    | N/A                      |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.30 | untested    | N/A                      |
 | Kubernetes 1.29 | untested    | N/A                      |
 | Kubernetes 1.28 | untested    | N/A                      |
-| Kubernetes 1.27 | untested    | N/A                      |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -17,8 +17,8 @@ spec:
   type: equinixmetal
   kubernetes:
     versions:
-    - version: 1.27.2
-      #expirationDate: "2023-03-15T23:59:59Z"
+    - version: 1.31.0
+      #expirationDate: "2025-10-28T23:59:59Z"
   machineImages:
   - name: flatcar
     versions:

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -138,7 +138,7 @@ spec:
   networking:
     type: calico
   kubernetes:
-    version: 1.27.2
+    version: 1.31.0
   maintenance:
     autoUpdate:
       kubernetesVersion: true

--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -166,7 +166,7 @@ spec:
         - --service-account-signing-key-file=/srv/kubernetes/service-account-key/id_rsa
         - --service-account-key-file=/srv/kubernetes/service-account-key-bundle/bundle.key
         - --v=2
-        image: registry.k8s.io/kube-apiserver:v1.28.2
+        image: registry.k8s.io/kube-apiserver:v1.31.0
         imagePullPolicy: IfNotPresent
         name: kube-apiserver
         ports:

--- a/example/26-cloudprofile.yaml
+++ b/example/26-cloudprofile.yaml
@@ -6,8 +6,8 @@ spec:
   type: equinixmetal
   kubernetes:
     versions:
-    - version: 1.27.2
-      #expirationDate: "2023-03-15T23:59:59Z"
+    - version: 1.31.0
+      #expirationDate: "2025-10-28T23:59:59Z"
   machineImages:
   - name: flatcar
     versions:

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -36,7 +36,7 @@ spec:
     kind: Shoot
     spec:
       kubernetes:
-        version: 1.28.2
+        version: 1.31.0
     status:
       lastOperation:
         state: Succeeded

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -29,7 +29,7 @@ spec:
       - ewr1
       - ny5
   kubernetes:
-    version: 1.28.2
+    version: 1.31.0
     kubelet:
       failSwapOn: false
   networking:

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -65,7 +65,7 @@ var _ = Describe("ValuesProvider", func() {
 						Pods: &cidr,
 					},
 					Kubernetes: gardencorev1beta1.Kubernetes{
-						Version: "1.28.2",
+						Version: "1.31.0",
 						VerticalPodAutoscaler: &gardencorev1beta1.VerticalPodAutoscaler{
 							Enabled: true,
 						},

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -63,12 +63,12 @@ var _ = Describe("Ensurer", func() {
 			},
 		)
 		extObjectKey   = client.ObjectKey{Namespace: namespace, Name: "my-shoot"}
-		eContextK8s126 = gcontext.NewInternalGardenContext(
+		eContextK8s131 = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				Shoot: &gardencorev1beta1.Shoot{
 					Spec: gardencorev1beta1.ShootSpec{
 						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.26.0",
+							Version: "1.31.0",
 						},
 					},
 					Status: gardencorev1beta1.ShootStatus{
@@ -123,9 +123,9 @@ var _ = Describe("Ensurer", func() {
 			ensurer := NewEnsurer(c, logger)
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s126, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s131, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep, "1.26.0", annotations)
+			checkKubeAPIServerDeployment(dep, "1.31.0", annotations)
 		})
 
 		It("should modify existing elements of kube-apiserver deployment", func() {
@@ -156,9 +156,9 @@ var _ = Describe("Ensurer", func() {
 			ensurer := NewEnsurer(c, logger)
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s126, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s131, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep, "1.26.0", annotations)
+			checkKubeAPIServerDeployment(dep, "1.31.0", annotations)
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform equinix-metal

**What this PR does / why we need it**:
Drop support for Shoots, Seeds and Gardens with Kubernetes version <= 1.28.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12409

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`provider-equnix-metal` no longer supports Shoots with Кubernetes version <= 1.28.
```
