### PR TITLE
fix(controller/worker/machines.go): add maxSurge, maxUnavailable and Strategy to generated machineDeployment

### DIFF
--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-provider-equinix-metal/charts"
@@ -320,19 +321,37 @@ var _ = Describe("Machines", func() {
 
 					machineDeployments = worker.MachineDeployments{
 						{
-							Name:                 machineClassNamePool1,
-							ClassName:            machineClassWithHashPool1,
-							SecretName:           machineClassWithHashPool1,
-							Minimum:              minPool1,
-							Maximum:              maxPool1,
+							Name:       machineClassNamePool1,
+							ClassName:  machineClassWithHashPool1,
+							SecretName: machineClassWithHashPool1,
+							Minimum:    minPool1,
+							Maximum:    maxPool1,
+							Strategy: machinev1alpha1.MachineDeploymentStrategy{
+								Type: machinev1alpha1.RollingUpdateMachineDeploymentStrategyType,
+								RollingUpdate: &machinev1alpha1.RollingUpdateMachineDeployment{
+									UpdateConfiguration: machinev1alpha1.UpdateConfiguration{
+										MaxUnavailable: ptr.To(maxUnavailablePool1),
+										MaxSurge:       ptr.To(maxSurgePool1),
+									},
+								},
+							},
 							MachineConfiguration: machineConfiguration,
 						},
 						{
-							Name:                 machineClassNamePool2,
-							ClassName:            machineClassWithHashPool2,
-							SecretName:           machineClassWithHashPool2,
-							Minimum:              minPool2,
-							Maximum:              maxPool2,
+							Name:       machineClassNamePool2,
+							ClassName:  machineClassWithHashPool2,
+							SecretName: machineClassWithHashPool2,
+							Minimum:    minPool2,
+							Maximum:    maxPool2,
+							Strategy: machinev1alpha1.MachineDeploymentStrategy{
+								Type: machinev1alpha1.RollingUpdateMachineDeploymentStrategyType,
+								RollingUpdate: &machinev1alpha1.RollingUpdateMachineDeployment{
+									UpdateConfiguration: machinev1alpha1.UpdateConfiguration{
+										MaxUnavailable: ptr.To(maxUnavailablePool2),
+										MaxSurge:       ptr.To(maxSurgePool2),
+									},
+								},
+							},
 							MachineConfiguration: machineConfiguration,
 						},
 					}
@@ -345,7 +364,6 @@ var _ = Describe("Machines", func() {
 					expectGetUserDataSecretCallToWork()
 
 					// Test workerDelegate.DeployMachineClasses()
-
 					chartApplier.
 						EXPECT().
 						ApplyFromEmbeddedFS(
@@ -372,7 +390,6 @@ var _ = Describe("Machines", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					// Test workerDelegate.GenerateMachineDeployments()
-
 					result, err := workerDelegate.GenerateMachineDeployments(ctx)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(machineDeployments))


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform equinix-metal

**What this PR does / why we need it**:
Currently we are lacking the above field ind the machineDeployment, resulting in reoncile errors in MCM

\
**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
correctly translate `worker` to `machineDeployments`
```
