### PR TITLE
fix(workflows/build.yaml): add required workflow permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,7 @@ jobs:
       version-commit-callback-action-path: .github/actions/prepare-release
     permissions:
       contents: read
-      packages: write
-      id-token: write
+      pull-requests: write
 
   oci-images:
     name: Build OCI-Images
@@ -30,6 +29,8 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      pull-requests: write
+    secrets: inherit  
     uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@master
     with:
       name: gardener-extension-provider-equinix-metal
@@ -48,6 +49,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      pull-requests: write
     uses: gardener/cc-utils/.github/workflows/helmchart-ocm.yaml@master
     strategy:
       matrix:
@@ -67,6 +69,9 @@ jobs:
       ocm-mappings: ${{ toJSON(matrix.args.mappings) }}
 
   verify:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -9,11 +9,18 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
+    secrets: inherit
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      pull-requests: write
 
   component-descriptor:
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build
+    secrets: inherit
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,11 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
+      pull-requests: write
     with:
       mode: release
 
@@ -20,8 +25,11 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/release.yaml@master
     needs:
       - build
-    secrets:
-      github-app-secret-key: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
+    secrets: inherit
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
     with:
       release-commit-target: branch
       next-version: ${{ inputs.next-version }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug
/platform equinix-metal

**What this PR does / why we need it**:
GH actions stoppped working. This updates the workflow permissions to match other repositories

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
